### PR TITLE
Add Kling Video V2 nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ The package defines nodes grouped by modality. Each node is a subclass of `FALNo
 
 ### Image to Video
 
-- **HaiperImageToVideo**, **LumaDreamMachine**, **KlingVideo**, **KlingVideoPro** – convert an image into a short video clip with control over duration and style.
+- **HaiperImageToVideo**, **LumaDreamMachine**, **KlingVideo**, **KlingVideoPro**, **KlingVideoV2** – convert an image into a short video clip with control over duration and style.
 - **CogVideoX**, **MiniMaxVideo**, **MiniMaxHailuo02**, **LTXVideo**, **StableVideo**, **FastSVD**, **AMTInterpolation**, **SadTalker**, **MuseTalk** – additional models for motion synthesis, interpolation and talking‑face generation.
+
+### Text to Video
+
+- **KlingTextToVideoV2** – create short video clips directly from text prompts.
 
 ### Text to Audio
 

--- a/src/nodetool/dsl/fal/text_to_video.py
+++ b/src/nodetool/dsl/fal/text_to_video.py
@@ -5,6 +5,85 @@ import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 
+import nodetool.nodes.fal.image_to_video
+import nodetool.nodes.fal.image_to_video
+
+
+class KlingTextToVideoV2(GraphNode):
+    """
+    Generate videos directly from text prompts using Kling Video V2 Master.
+    video, generation, animation, text-to-video, kling-v2
+
+    Use cases:
+    - Visualize scripts or storyboards
+    - Produce short promotional videos from text
+    - Create animated social media content
+    - Generate concept previews for film ideas
+    - Produce text-driven motion graphics
+    """
+
+    KlingDuration: typing.ClassVar[type] = (
+        nodetool.nodes.fal.image_to_video.KlingDuration
+    )
+    AspectRatio: typing.ClassVar[type] = nodetool.nodes.fal.image_to_video.AspectRatio
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="The prompt describing the desired video"
+    )
+    duration: nodetool.nodes.fal.image_to_video.KlingDuration = Field(
+        default=nodetool.nodes.fal.image_to_video.KlingDuration.FIVE_SECONDS,
+        description="The duration of the generated video",
+    )
+    aspect_ratio: nodetool.nodes.fal.image_to_video.AspectRatio = Field(
+        default=nodetool.nodes.fal.image_to_video.AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated video frame",
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.text_to_video.KlingTextToVideoV2"
+
+
+import nodetool.nodes.fal.image_to_video
+import nodetool.nodes.fal.image_to_video
+
+
+class KlingVideoV2(GraphNode):
+    """
+    Generate videos from images using Kling Video V2 Master. Create smooth and realistic animations from a single frame.
+    video, generation, animation, img2vid, kling-v2
+
+    Use cases:
+    - Convert artwork into animated clips
+    - Produce dynamic marketing visuals
+    - Generate motion graphics from static scenes
+    - Create short cinematic sequences
+    - Enhance presentations with video content
+    """
+
+    KlingDuration: typing.ClassVar[type] = (
+        nodetool.nodes.fal.image_to_video.KlingDuration
+    )
+    AspectRatio: typing.ClassVar[type] = nodetool.nodes.fal.image_to_video.AspectRatio
+    image: types.ImageRef | GraphNode | tuple[GraphNode, str] = Field(
+        default=types.ImageRef(type="image", uri="", asset_id=None, data=None),
+        description="The image to transform into a video",
+    )
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="A description of the desired video motion and style"
+    )
+    duration: nodetool.nodes.fal.image_to_video.KlingDuration = Field(
+        default=nodetool.nodes.fal.image_to_video.KlingDuration.FIVE_SECONDS,
+        description="The duration of the generated video",
+    )
+    aspect_ratio: nodetool.nodes.fal.image_to_video.AspectRatio = Field(
+        default=nodetool.nodes.fal.image_to_video.AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated video frame",
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.text_to_video.KlingVideoV2"
+
 
 class PixverseEffects(GraphNode):
     """Apply text-driven effects to a video with Pixverse 4.5.

--- a/src/nodetool/package_metadata/nodetool-fal.json
+++ b/src/nodetool/package_metadata/nodetool-fal.json
@@ -4309,6 +4309,140 @@
       ]
     },
     {
+      "title": "Kling Text To Video V 2",
+      "description": "Generate videos directly from text prompts using Kling Video V2 Master.\n    video, generation, animation, text-to-video, kling-v2\n\n    Use cases:\n    - Visualize scripts or storyboards\n    - Produce short promotional videos from text\n    - Create animated social media content\n    - Generate concept previews for film ideas\n    - Produce text-driven motion graphics",
+      "namespace": "fal.text_to_video",
+      "node_type": "fal.text_to_video.KlingTextToVideoV2",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt describing the desired video"
+        },
+        {
+          "name": "duration",
+          "type": {
+            "type": "enum",
+            "values": [
+              "5",
+              "10"
+            ],
+            "type_name": "nodetool.nodes.fal.image_to_video.KlingDuration"
+          },
+          "default": "5",
+          "title": "Duration",
+          "description": "The duration of the generated video"
+        },
+        {
+          "name": "aspect_ratio",
+          "type": {
+            "type": "enum",
+            "values": [
+              "16:9",
+              "9:16",
+              "4:3",
+              "3:4",
+              "21:9",
+              "9:21",
+              "1:1"
+            ],
+            "type_name": "nodetool.nodes.fal.image_to_video.AspectRatio"
+          },
+          "default": "16:9",
+          "title": "Aspect Ratio",
+          "description": "The aspect ratio of the generated video frame"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "video"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "duration"
+      ]
+    },
+    {
+      "title": "Kling Video V 2",
+      "description": "Generate videos from images using Kling Video V2 Master. Create smooth and realistic animations from a single frame.\n    video, generation, animation, img2vid, kling-v2\n\n    Use cases:\n    - Convert artwork into animated clips\n    - Produce dynamic marketing visuals\n    - Generate motion graphics from static scenes\n    - Create short cinematic sequences\n    - Enhance presentations with video content",
+      "namespace": "fal.text_to_video",
+      "node_type": "fal.text_to_video.KlingVideoV2",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The image to transform into a video"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "A description of the desired video motion and style"
+        },
+        {
+          "name": "duration",
+          "type": {
+            "type": "enum",
+            "values": [
+              "5",
+              "10"
+            ],
+            "type_name": "nodetool.nodes.fal.image_to_video.KlingDuration"
+          },
+          "default": "5",
+          "title": "Duration",
+          "description": "The duration of the generated video"
+        },
+        {
+          "name": "aspect_ratio",
+          "type": {
+            "type": "enum",
+            "values": [
+              "16:9",
+              "9:16",
+              "4:3",
+              "3:4",
+              "21:9",
+              "9:21",
+              "1:1"
+            ],
+            "type_name": "nodetool.nodes.fal.image_to_video.AspectRatio"
+          },
+          "default": "16:9",
+          "title": "Aspect Ratio",
+          "description": "The aspect ratio of the generated video frame"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "video"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "prompt",
+        "duration"
+      ]
+    },
+    {
       "title": "Pixverse Effects",
       "description": "Apply text-driven effects to a video with Pixverse 4.5.\n    video, effects, pixverse, text-guided\n\n    Use cases:\n    - Stylize existing footage\n    - Add visual effects via text\n    - Enhance marketing videos\n    - Create experimental clips\n    - Transform user content",
       "namespace": "fal.text_to_video",


### PR DESCRIPTION
## Summary
- add `KlingVideoV2` and `KlingTextToVideoV2` nodes
- expose new nodes via `__init__`
- document new video nodes in README
- generate DSL module for `text_to_video`

## Testing
- `ruff check src/nodetool/nodes/fal/text_to_video.py src/nodetool/dsl/fal/text_to_video.py`
- `black --check src/nodetool/nodes/fal/text_to_video.py src/nodetool/dsl/fal/text_to_video.py`
- `pytest -q`