### PR TITLE
Add WanFlf2v node

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+extend-exclude = ["src/nodetool/dsl"]

--- a/src/nodetool/dsl/fal/image_to_video.py
+++ b/src/nodetool/dsl/fal/image_to_video.py
@@ -658,3 +658,35 @@ class Veo2ImageToVideo(GraphNode):
     @classmethod
     def get_node_type(cls):
         return "fal.image_to_video.Veo2ImageToVideo"
+
+
+class WanFlf2v(GraphNode):
+    """
+    Generate short video clips from a single image using the WAN FLF2V model. This model converts a still image into an animated clip guided by a text prompt.
+    video, generation, animation, image-to-video, wan
+
+    Use cases:
+    - Animate still images into short clips
+    - Create dynamic content from artwork
+    - Produce promotional video snippets
+    - Generate visual effects for social posts
+    - Explore creative motion ideas
+    """
+
+    image: types.ImageRef | GraphNode | tuple[GraphNode, str] = Field(
+        default=types.ImageRef(type="image", uri="", asset_id=None, data=None),
+        description="The source image for video generation",
+    )
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="Description of the desired motion and style"
+    )
+    num_frames: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=16, description="Number of frames to generate"
+    )
+    seed: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=-1, description="The same seed will output the same video every time"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.image_to_video.WanFlf2v"

--- a/src/nodetool/package_metadata/nodetool-fal.json
+++ b/src/nodetool/package_metadata/nodetool-fal.json
@@ -6196,6 +6196,64 @@
       ]
     },
     {
+      "title": "Wan Flf 2 v",
+      "description": "Generate short video clips from a single image using the WAN FLF2V model. This model converts a still image into an animated clip guided by a text prompt.\n    video, generation, animation, image-to-video, wan\n\n    Use cases:\n    - Animate still images into short clips\n    - Create dynamic content from artwork\n    - Produce promotional video snippets\n    - Generate visual effects for social posts\n    - Explore creative motion ideas",
+      "namespace": "fal.image_to_video",
+      "node_type": "fal.image_to_video.WanFlf2v",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The source image for video generation"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "Description of the desired motion and style"
+        },
+        {
+          "name": "num_frames",
+          "type": {
+            "type": "int"
+          },
+          "default": 16,
+          "title": "Num Frames",
+          "description": "Number of frames to generate",
+          "min": 1.0
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same video every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "video"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "prompt",
+        "num_frames"
+      ]
+    },
+    {
       "title": "Bria Background Remove",
       "description": "Bria RMBG 2.0 enables seamless removal of backgrounds from images, ideal for professional editing tasks.\n    Trained exclusively on licensed data for safe and risk-free commercial use.",
       "namespace": "fal.image_to_image",


### PR DESCRIPTION
## Summary
- add WanFlf2v node for turning an image into a short video clip
- include metadata in pyproject
- generate package metadata
- exclude generated DSL from Ruff
- format source files with Black

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
