### PR TITLE
Add PixVerse v4.5 image-to-video node

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --with dev
+      - name: Run tests
+        run: |
+          poetry run pytest -ra

--- a/.github/workflows/text2image.yml
+++ b/.github/workflows/text2image.yml
@@ -1,0 +1,21 @@
+name: Text2Image Example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-text2image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run example node
+        env:
+          FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
+        run: python examples/run_text2image.py

--- a/.github/workflows/text2image.yml
+++ b/.github/workflows/text2image.yml
@@ -19,3 +19,8 @@ jobs:
         env:
           FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
         run: python examples/run_text2image.py
+      - name: Upload generated image
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-image
+          path: generated_image.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,57 @@ nodetool package scan
 nodetool codegen
 ```
 
+### DSL Generation Process
+
+When you add a new FAL node, `nodetool codegen` automatically generates corresponding DSL classes in `src/nodetool/dsl/fal/`. Here's how the process works:
+
+1. **Package Scan**: `nodetool package scan` discovers your new node classes and generates metadata
+2. **Code Generation**: `nodetool codegen` creates DSL wrapper classes based on the node metadata
+
+**Example**: If you create a new node `LumaDreamMachine` in `src/nodetool/nodes/fal/image_to_video.py`, the codegen will automatically create a corresponding DSL class in `src/nodetool/dsl/fal/image_to_video.py`:
+
+```python
+class LumaDreamMachine(GraphNode):
+    """
+    Generate video clips from your images using Luma Dream Machine v1.5. Supports various aspect ratios and optional end-frame blending.
+    video, generation, animation, blending, aspect-ratio, img2vid, image-to-video
+
+    Use cases:
+    - Create seamless video loops
+    - Generate video transitions
+    - Transform images into animations
+    - Create motion graphics
+    - Produce video content
+    """
+
+    image: ImageRef | GraphNode | tuple[GraphNode, str] = Field(
+        default=ImageRef(), description="The image to transform into a video"
+    )
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="A description of the desired video motion and style"
+    )
+    aspect_ratio: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="16:9", description="The aspect ratio of the generated video"
+    )
+    loop: bool | GraphNode | tuple[GraphNode, str] = Field(
+        default=False, description="Whether the video should loop (end blends with beginning)"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.image_to_video.LumaDreamMachine"
+```
+
+**Key DSL Features**:
+- All field types become unions with `GraphNode` and `tuple[GraphNode, str]` for graph connectivity
+- Enum fields are converted to string types in DSL
+- The `get_node_type()` method returns the fully qualified node path
+- Docstrings and field descriptions are preserved
+
+**File Organization**: DSL files mirror the node file structure:
+- `src/nodetool/nodes/fal/image_to_video.py` → `src/nodetool/dsl/fal/image_to_video.py`
+- `src/nodetool/nodes/fal/text_to_image.py` → `src/nodetool/dsl/fal/text_to_image.py`
+
 ## Linting and Tests
 
 Before submitting a pull request, run the following checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,144 @@ This repository provides additional nodes for the [nodetool](https://github.com/
 - Each node must contain a short docstring describing the model and several example use cases.
 - Provide a `get_basic_fields` class method listing the most relevant fields
 
+## Adding a New FAL Node
+
+### Step 1: Analyze the OpenAPI Schema
+
+When adding a new FAL node from an OpenAPI schema, first extract the key information:
+
+1. **Endpoint ID**: Found in `x-fal-metadata.endpointId` (e.g., `fal-ai/luma-dream-machine/image-to-video`)
+2. **Input Schema**: Look for the main input schema (e.g., `LumaDreamMachineImageToVideoInput`)
+3. **Output Schema**: Look for the main output schema (e.g., `LumaDreamMachineImageToVideoOutput`)
+
+### Step 2: Create the Node Class
+
+Create a new class in the appropriate file under `src/nodetool/nodes/fal/`:
+
+```python
+from pydantic import Field
+from enum import Enum
+from nodetool.metadata.types import ImageRef, VideoRef
+from nodetool.nodes.fal.fal_node import FALNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+class AspectRatio(Enum):
+    RATIO_16_9 = "16:9"
+    RATIO_9_16 = "9:16"
+    # ... add other ratios from schema
+
+class LumaDreamMachine(FALNode):
+    """
+    Generate video clips from your images using Luma Dream Machine v1.5. Supports various aspect ratios and optional end-frame blending.
+    video, generation, animation, blending, aspect-ratio, img2vid, image-to-video
+
+    Use cases:
+    - Create seamless video loops
+    - Generate video transitions
+    - Transform images into animations
+    - Create motion graphics
+    - Produce video content
+    """
+
+    # Map OpenAPI schema properties to pydantic Fields
+    image: ImageRef = Field(
+        default=ImageRef(), description="The image to transform into a video"
+    )
+    prompt: str = Field(
+        default="", description="A description of the desired video motion and style"
+    )
+    aspect_ratio: AspectRatio = Field(
+        default=AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated video",
+    )
+    loop: bool = Field(
+        default=False,
+        description="Whether the video should loop (end blends with beginning)",
+    )
+    end_image: ImageRef | None = Field(
+        default=None, description="Optional image to blend the end of the video with"
+    )
+
+    async def process(self, context: ProcessingContext) -> VideoRef:
+        # Convert images to base64
+        image_base64 = await context.image_to_base64(self.image)
+
+        # Build arguments dict matching OpenAPI schema
+        arguments = {
+            "image_url": f"data:image/png;base64,{image_base64}",
+            "prompt": self.prompt,
+            "aspect_ratio": self.aspect_ratio.value,
+            "loop": self.loop,
+        }
+
+        # Handle optional fields
+        if self.end_image:
+            end_image_base64 = await context.image_to_base64(self.end_image)
+            arguments["end_image_url"] = f"data:image/png;base64,{end_image_base64}"
+
+        # Submit request using the endpoint ID
+        res = await self.submit_request(
+            context=context,
+            application="fal-ai/luma-dream-machine/image-to-video",
+            arguments=arguments,
+        )
+        
+        # Extract result based on output schema
+        assert "video" in res
+        return VideoRef(uri=res["video"]["url"])
+
+    @classmethod
+    def get_basic_fields(cls):
+        return ["image", "prompt", "aspect_ratio"]
+```
+
+### Step 3: Map OpenAPI Types to Python Types
+
+Common mappings:
+- `string` → `str`
+- `integer` → `int`
+- `number` → `float`
+- `boolean` → `bool`
+- `array` → `list[T]`
+- `enum` → Create Python `Enum` class
+- File references → `ImageRef`, `VideoRef`, `AudioRef`
+
+### Step 4: Handle Input Processing
+
+For different input types:
+- **Images**: Use `await context.image_to_base64(self.image)` and format as `data:image/png;base64,{base64}`
+- **Videos**: Use `await context.asset_to_bytes(self.video)` and upload with `await client.upload(video_bytes, "video/mp4")`
+- **Audio**: Use `await context.asset_to_bytes(self.audio)` and upload with `await client.upload(audio_bytes, "audio/mp3")`
+
+### Step 5: Handle Output Processing
+
+Based on the output schema:
+- **Single image**: `return ImageRef(uri=res["images"][0]["url"])`
+- **Single video**: `return VideoRef(uri=res["video"]["url"])`
+- **Multiple outputs**: Return appropriate reference type or dict
+- **Complex outputs**: Define custom return type with `@classmethod def return_type(cls)`
+
+### Step 6: Add Enums for Constrained Values
+
+For schema properties with `enum` values:
+
+```python
+class AspectRatio(Enum):
+    RATIO_16_9 = "16:9"
+    RATIO_9_16 = "9:16"
+    RATIO_4_3 = "4:3"
+    RATIO_3_4 = "3:4"
+```
+
+### Best Practices
+
+1. **Docstring Format**: First line describes the model, second line contains comma-separated tags, followed by use cases
+2. **Field Descriptions**: Use clear, descriptive text from the OpenAPI schema
+3. **Default Values**: Set sensible defaults based on schema defaults
+4. **Optional Fields**: Handle conditional arguments properly
+5. **Error Handling**: Always assert expected output fields exist
+6. **Naming**: Use descriptive class names that reflect the model/functionality
+
 ## Commands
 
 After adding or changing nodes run these commands to generate metadata and DSL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,203 @@ This repository provides additional nodes for the [nodetool](https://github.com/
 - Each node must contain a short docstring describing the model and several example use cases.
 - Provide a `get_basic_fields` class method listing the most relevant fields
 
+## Adding a New FAL Node from OpenAPI Schema
+
+When implementing a new FAL node from an OpenAPI specification, follow this systematic approach:
+
+### 1. Extract Key Information from OpenAPI Schema
+
+From the OpenAPI JSON, identify:
+- **Endpoint ID**: `x-fal-metadata.endpointId` (e.g., `"fal-ai/luma-dream-machine/image-to-video"`)
+- **Input Schema**: Main input schema name (e.g., `LumaDreamMachineImageToVideoInput`)
+- **Output Schema**: Main output schema name (e.g., `LumaDreamMachineImageToVideoOutput`)
+- **Required/Optional Fields**: Check `required` array in schema properties
+
+### 2. Node Implementation Template
+
+```python
+from pydantic import Field
+from enum import Enum
+from nodetool.metadata.types import ImageRef, VideoRef, AudioRef
+from nodetool.nodes.fal.fal_node import FALNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+# Create enums for constrained values
+class AspectRatio(Enum):
+    RATIO_16_9 = "16:9"
+    RATIO_9_16 = "9:16"
+    RATIO_4_3 = "4:3"
+    RATIO_3_4 = "3:4"
+    RATIO_21_9 = "21:9"
+    RATIO_9_21 = "9:21"
+
+class YourModelName(FALNode):
+    """
+    Brief description of what the model does and its capabilities.
+    comma, separated, tags, describing, functionality, category
+    
+    Use cases:
+    - First use case example
+    - Second use case example
+    - Third use case example
+    - Fourth use case example
+    - Fifth use case example
+    """
+    
+    # Map OpenAPI properties to pydantic Fields
+    prompt: str = Field(
+        default="", description="Description from OpenAPI schema"
+    )
+    image: ImageRef = Field(
+        default=ImageRef(), description="Input image description"
+    )
+    aspect_ratio: AspectRatio = Field(
+        default=AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated output",
+    )
+    loop: bool = Field(
+        default=False, description="Boolean field description"
+    )
+    
+    async def process(self, context: ProcessingContext) -> VideoRef:
+        # Handle different input types
+        if hasattr(self, 'image') and self.image.uri:
+            image_base64 = await context.image_to_base64(self.image)
+            
+        # Build arguments matching OpenAPI schema
+        arguments = {
+            "prompt": self.prompt,
+            "aspect_ratio": self.aspect_ratio.value,
+            "loop": self.loop,
+        }
+        
+        # Handle image inputs
+        if hasattr(self, 'image') and self.image.uri:
+            arguments["image_url"] = f"data:image/png;base64,{image_base64}"
+            
+        # Handle optional fields
+        if hasattr(self, 'optional_field') and self.optional_field:
+            arguments["optional_field"] = self.optional_field
+            
+        # Submit request
+        res = await self.submit_request(
+            context=context,
+            application="endpoint-id-from-openapi-schema",
+            arguments=arguments,
+        )
+        
+        # Handle output based on schema
+        assert "expected_output_key" in res
+        return VideoRef(uri=res["expected_output_key"]["url"])
+    
+    @classmethod
+    def get_basic_fields(cls):
+        return ["prompt", "image", "aspect_ratio"]  # Most important fields
+```
+
+### 3. Type Mapping Guide
+
+| OpenAPI Type | Python Type | nodetool Type |
+|--------------|-------------|---------------|
+| `string` | `str` | `str` |
+| `integer` | `int` | `int` |
+| `number` | `float` | `float` |
+| `boolean` | `bool` | `bool` |
+| `array` | `list[T]` | `list[T]` |
+| `enum` | `Enum` | Custom `Enum` class |
+| Image URL | `str` | `ImageRef` |
+| Video URL | `str` | `VideoRef` |
+| Audio URL | `str` | `AudioRef` |
+
+### 4. Input Processing Patterns
+
+**For Images:**
+```python
+image_base64 = await context.image_to_base64(self.image)
+arguments["image_url"] = f"data:image/png;base64,{image_base64}"
+```
+
+**For Videos:**
+```python
+client = self.get_client(context)
+video_bytes = await context.asset_to_bytes(self.video)
+video_url = await client.upload(video_bytes, "video/mp4")
+arguments["video_url"] = video_url
+```
+
+**For Audio:**
+```python
+client = self.get_client(context)  
+audio_bytes = await context.asset_to_bytes(self.audio)
+audio_url = await client.upload(audio_bytes, "audio/mp3")
+arguments["audio_url"] = audio_url
+```
+
+### 5. Output Processing Patterns
+
+**Single Image Output:**
+```python
+assert res["images"] is not None
+assert len(res["images"]) > 0
+return ImageRef(uri=res["images"][0]["url"])
+```
+
+**Single Video Output:**
+```python
+assert "video" in res
+return VideoRef(uri=res["video"]["url"])
+```
+
+**Complex/Multiple Outputs:**
+```python
+@classmethod
+def return_type(cls):
+    return {
+        "text": str,
+        "chunks": list[dict],
+        "metadata": dict,
+    }
+
+# In process method:
+return {
+    "text": result["text"],
+    "chunks": result["chunks"], 
+    "metadata": result.get("metadata", {}),
+}
+```
+
+### 6. Special Considerations
+
+**Conditional Parameters:** Handle optional fields that should only be included when set:
+```python
+if self.seed != -1:
+    arguments["seed"] = self.seed
+```
+
+**File Organization:** Place nodes in appropriate files:
+- `text_to_image.py` - Text-to-image models
+- `image_to_image.py` - Image transformation models  
+- `image_to_video.py` - Image-to-video models
+- `speech_to_text.py` - Speech recognition models
+- Create new files for new categories as needed
+
+**Error Handling:** Always validate expected outputs:
+```python
+assert "expected_key" in res
+assert res["expected_key"] is not None
+```
+
+### 7. Documentation Requirements
+
+1. **Docstring Format**: 
+   - Line 1: Clear description of functionality
+   - Line 2: Comma-separated tags for searchability  
+   - Lines 3+: 5 concrete use cases
+
+2. **Field Descriptions**: Use exact or adapted descriptions from OpenAPI schema
+
+3. **get_basic_fields**: Return 3-5 most important fields for UI display
+
 ## Commands
 
 After adding or changing nodes run these commands to generate metadata and DSL.

--- a/examples/run_text2image.py
+++ b/examples/run_text2image.py
@@ -1,0 +1,22 @@
+import asyncio
+import os
+
+from nodetool.nodes.fal.text_to_image import IdeogramV2
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+async def main() -> None:
+    # Create node with a simple prompt
+    node = IdeogramV2(prompt="a colorful parrot")
+
+    # FAL_API_KEY must be provided via environment variables
+    context = ProcessingContext(
+        environment={"FAL_API_KEY": os.getenv("FAL_API_KEY", "")}
+    )
+
+    image = await node.process(context)
+    print("Generated image URL:", image.uri)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/run_text2image.py
+++ b/examples/run_text2image.py
@@ -17,6 +17,15 @@ async def main() -> None:
     image = await node.process(context)
     print("Generated image URL:", image.uri)
 
+    # Download the generated image so it can be uploaded as a workflow artifact
+    import urllib.request
+
+    with urllib.request.urlopen(image.uri) as response, open(
+        "generated_image.png", "wb"
+    ) as out_file:
+        out_file.write(response.read())
+    print("Image saved to generated_image.png")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -757,12 +757,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\" or os_name == \"nt\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or os_name == \"nt\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coloredlogs"
@@ -1536,6 +1536,18 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
 type = ["pytest-mypy"]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
 
 [[package]]
 name = "itsdangerous"
@@ -2488,7 +2500,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -2701,6 +2713,22 @@ files = [
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
 type = ["mypy (>=1.11.2)"]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "posthog"
@@ -3169,6 +3197,27 @@ files = [
     {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
     {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -4328,4 +4377,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "86fb86514f4b956c2e89bbd12fbf295a94476cb6c34f8f92552621d67865e18d"
+content-hash = "5ba4c8f94333c625a6cbdcd115093982d4e181322f533d362d36c87a93ba5008"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,9 @@ pytest = "*"
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+
+[tool.ruff]
+exclude = ["src/nodetool/dsl/*"]
+
+[tool.black]
+extend-exclude = 'src/nodetool/nodes/fal/(speech_to_text|image_to_image)\.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = ["Matthias Georgi <matti.georgi@gmail.com>"]
 packages = [{ include = "nodetool", from = "src" }]
 package-mode = true
-include = []
+include = ["src/nodetool/package_metadata/nodetool-fal.json"]
 repository = "https://github.com/nodetool-ai/nodetool-fal"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,9 @@ repository = "https://github.com/nodetool-ai/nodetool-fal"
 python = "^3.11"
 nodetool-core = { git = "https://github.com/nodetool-ai/nodetool-core.git", rev = "main" }
 fal-client = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
+[tool.pytest.ini_options]
+addopts = "-ra"

--- a/src/nodetool/dsl/fal/image_to_image.py
+++ b/src/nodetool/dsl/fal/image_to_image.py
@@ -223,6 +223,30 @@ class BriaProductShot(GraphNode):
         return "fal.image_to_image.BriaProductShot"
 
 
+class ClarityUpscaler(GraphNode):
+    """Upscale images to improve resolution and sharpness.
+
+    clarity, upscale, enhancement
+
+    Use cases:
+    - Increase image resolution for printing
+    - Improve clarity of low-quality images
+    - Enhance textures and graphics
+    """
+
+    image: types.ImageRef | GraphNode | tuple[GraphNode, str] = Field(
+        default=types.ImageRef(type="image", uri="", asset_id=None, data=None),
+        description="Input image to upscale",
+    )
+    scale: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=2, description="Upscaling factor"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.image_to_image.ClarityUpscaler"
+
+
 import nodetool.nodes.fal.text_to_image
 
 

--- a/src/nodetool/dsl/fal/image_to_video.py
+++ b/src/nodetool/dsl/fal/image_to_video.py
@@ -404,6 +404,48 @@ class MuseTalk(GraphNode):
         return "fal.image_to_video.MuseTalk"
 
 
+class PixVerse(GraphNode):
+    """
+    Generate dynamic videos from images with PixVerse v4.5. Create high-quality motion
+    with detailed prompt control and advanced diffusion parameters.
+    video, generation, pixverse, motion, diffusion, img2vid, image-to-video
+
+    Use cases:
+    - Animate illustrations and photos
+    - Produce engaging social media clips
+    - Generate short cinematic shots
+    - Create motion for product showcases
+    - Experiment with creative video effects
+    """
+
+    image: types.ImageRef | GraphNode | tuple[GraphNode, str] = Field(
+        default=types.ImageRef(type="image", uri="", asset_id=None, data=None),
+        description="The image to transform into a video",
+    )
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="A description of the desired video motion and style"
+    )
+    negative_prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="low quality, worst quality, distorted, blurred",
+        description="What to avoid in the generated video",
+    )
+    num_inference_steps: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=50,
+        description="Number of inference steps (higher = better quality but slower)",
+    )
+    guidance_scale: float | GraphNode | tuple[GraphNode, str] = Field(
+        default=7.5,
+        description="How closely to follow the prompt (higher = more faithful)",
+    )
+    seed: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=-1, description="The same seed will output the same video every time"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.image_to_video.PixVerse"
+
+
 import nodetool.nodes.fal.image_to_video
 import nodetool.nodes.fal.image_to_video
 

--- a/src/nodetool/dsl/fal/text_to_image.py
+++ b/src/nodetool/dsl/fal/text_to_image.py
@@ -1,5 +1,6 @@
-from pydantic import Field
+from pydantic import BaseModel, Field
 import typing
+from typing import Any
 import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
@@ -1248,22 +1249,25 @@ class IllusionDiffusion(GraphNode):
 
 
 import nodetool.nodes.fal.text_to_image
+import nodetool.nodes.fal.text_to_image
 
 
 class Imagen4Preview(GraphNode):
     """
-    Imagen 4 is an advanced text-to-image model providing high quality and
-    detailed visuals with strong prompt understanding.
-    image, generation, diffusion, text-to-image, txt2img
+    Imagen 4 Preview is the next iteration of Google's Imagen series, offering
+    high quality text-to-image generation with strong prompt adherence and
+    improved realism.
+    image, generation, google, text-to-image, txt2img
 
     Use cases:
+    - Generate photorealistic artwork and designs
     - Create marketing and product visuals
-    - Generate concept art and illustrations
-    - Produce photorealistic images from descriptions
-    - Experiment with advanced diffusion capabilities
-    - Rapidly prototype visual ideas
+    - Produce concept art or storyboards
+    - Explore creative ideas with high fidelity
+    - Rapid prototyping of imagery
     """
 
+    AspectRatio: typing.ClassVar[type] = nodetool.nodes.fal.text_to_image.AspectRatio
     ImageSizePreset: typing.ClassVar[type] = (
         nodetool.nodes.fal.text_to_image.ImageSizePreset
     )
@@ -1271,8 +1275,11 @@ class Imagen4Preview(GraphNode):
         default="", description="The prompt to generate an image from"
     )
     negative_prompt: str | GraphNode | tuple[GraphNode, str] = Field(
-        default="",
-        description="Use it to address details that you don't want in the image",
+        default="", description="Elements to avoid in the generated image"
+    )
+    aspect_ratio: nodetool.nodes.fal.text_to_image.AspectRatio = Field(
+        default=nodetool.nodes.fal.text_to_image.AspectRatio.RATIO_1_1,
+        description="The aspect ratio of the generated image",
     )
     image_size: nodetool.nodes.fal.text_to_image.ImageSizePreset = Field(
         default=nodetool.nodes.fal.text_to_image.ImageSizePreset.LANDSCAPE_4_3,
@@ -1282,7 +1289,7 @@ class Imagen4Preview(GraphNode):
         default=50, description="The number of inference steps to perform"
     )
     guidance_scale: float | GraphNode | tuple[GraphNode, str] = Field(
-        default=5.0, description="How closely the model should stick to your prompt"
+        default=5.0, description="How closely the model should follow the prompt"
     )
     num_images: int | GraphNode | tuple[GraphNode, str] = Field(
         default=1, description="The number of images to generate"

--- a/src/nodetool/nodes/fal/__init__.py
+++ b/src/nodetool/nodes/fal/__init__.py
@@ -1,6 +1,6 @@
-import nodetool.nodes.fal.llm  # noqa: F401
-import nodetool.nodes.fal.text_to_image  # noqa: F401
-import nodetool.nodes.fal.text_to_audio  # noqa: F401
-import nodetool.nodes.fal.speech_to_text  # noqa: F401
-import nodetool.nodes.fal.image_to_image  # noqa: F401
-import nodetool.nodes.fal.image_to_video  # noqa: F401
+import nodetool.nodes.fal.llm
+import nodetool.nodes.fal.text_to_image
+import nodetool.nodes.fal.text_to_audio
+import nodetool.nodes.fal.speech_to_text
+import nodetool.nodes.fal.image_to_image
+import nodetool.nodes.fal.image_to_video

--- a/src/nodetool/nodes/fal/image_to_image.py
+++ b/src/nodetool/nodes/fal/image_to_image.py
@@ -6,6 +6,7 @@ from nodetool.nodes.fal.fal_node import FALNode
 from nodetool.workflows.processing_context import ProcessingContext
 from .text_to_image import ImageSizePreset
 
+
 class FluxSchnellRedux(FALNode):
     """
     FLUX.1 [schnell] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications with the core FLUX capabilities.
@@ -18,36 +19,31 @@ class FluxSchnellRedux(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to transform"
+        default=ImageRef(), description="The input image to transform"
     )
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=4,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=4, ge=1, description="The number of inference steps to perform"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     enable_safety_checker: bool = Field(
-        default=True,
-        description="If true, the safety checker will be enabled"
+        default=True, description="If true, the safety checker will be enabled"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "image_size": self.image_size.value,
             "num_inference_steps": self.num_inference_steps,
             "enable_safety_checker": self.enable_safety_checker,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -78,41 +74,35 @@ class FluxDevRedux(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to transform"
+        default=ImageRef(), description="The input image to transform"
     )
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     enable_safety_checker: bool = Field(
-        default=True,
-        description="If true, the safety checker will be enabled"
+        default=True, description="If true, the safety checker will be enabled"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "image_size": self.image_size.value,
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "enable_safety_checker": self.enable_safety_checker,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -142,41 +132,35 @@ class FluxProRedux(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to transform"
+        default=ImageRef(), description="The input image to transform"
     )
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     safety_tolerance: str = Field(
-        default="2",
-        description="Safety tolerance level (1-6, 1 being most strict)"
+        default="2", description="Safety tolerance level (1-6, 1 being most strict)"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "image_size": self.image_size.value,
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "safety_tolerance": self.safety_tolerance,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -206,38 +190,31 @@ class FluxProUltraRedux(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to transform"
+        default=ImageRef(), description="The input image to transform"
     )
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     safety_tolerance: str = Field(
-        default="2",
-        description="Safety tolerance level (1-6, 1 being most strict)"
+        default="2", description="Safety tolerance level (1-6, 1 being most strict)"
     )
     image_prompt_strength: float = Field(
-        default=0.1,
-        description="The strength of the image prompt, between 0 and 1"
+        default=0.1, description="The strength of the image prompt, between 0 and 1"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "image_size": self.image_size.value,
@@ -245,7 +222,7 @@ class FluxProUltraRedux(FALNode):
             "guidance_scale": self.guidance_scale,
             "safety_tolerance": self.safety_tolerance,
             "image_prompt_strength": self.image_prompt_strength,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -277,42 +254,33 @@ class FluxProFill(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to transform"
+        default=ImageRef(), description="The input image to transform"
     )
-    mask: ImageRef = Field(
-        default=ImageRef(),
-        description="The mask for inpainting"
-    )
+    mask: ImageRef = Field(default=ImageRef(), description="The mask for inpainting")
     prompt: str = Field(
-        default="",
-        description="The prompt to fill the masked part of the image"
+        default="", description="The prompt to fill the masked part of the image"
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     safety_tolerance: str = Field(
-        default="2",
-        description="Safety tolerance level (1-6, 1 being most strict)"
+        default="2", description="Safety tolerance level (1-6, 1 being most strict)"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
         mask_base64 = await context.image_to_base64(self.mask)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "mask_url": f"data:image/png;base64,{mask_base64}",
             "prompt": self.prompt,
             "num_inference_steps": self.num_inference_steps,
             "safety_tolerance": self.safety_tolerance,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -345,37 +313,29 @@ class FluxProCanny(FALNode):
 
     control_image: ImageRef = Field(
         default=ImageRef(),
-        description="The control image to generate the Canny edge map from"
+        description="The control image to generate the Canny edge map from",
     )
-    prompt: str = Field(
-        default="",
-        description="The prompt to generate an image from"
-    )
+    prompt: str = Field(default="", description="The prompt to generate an image from")
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     safety_tolerance: str = Field(
-        default="2",
-        description="Safety tolerance level (1-6, 1 being most strict)"
+        default="2", description="Safety tolerance level (1-6, 1 being most strict)"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         control_image_base64 = await context.image_to_base64(self.control_image)
-        
+
         arguments = {
             "control_image_url": f"data:image/png;base64,{control_image_base64}",
             "prompt": self.prompt,
@@ -383,7 +343,7 @@ class FluxProCanny(FALNode):
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "safety_tolerance": self.safety_tolerance,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -416,37 +376,29 @@ class FluxProDepth(FALNode):
 
     control_image: ImageRef = Field(
         default=ImageRef(),
-        description="The control image to generate the depth map from"
+        description="The control image to generate the depth map from",
     )
-    prompt: str = Field(
-        default="",
-        description="The prompt to generate an image from"
-    )
+    prompt: str = Field(default="", description="The prompt to generate an image from")
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     safety_tolerance: str = Field(
-        default="2",
-        description="Safety tolerance level (1-6, 1 being most strict)"
+        default="2", description="Safety tolerance level (1-6, 1 being most strict)"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         control_image_base64 = await context.image_to_base64(self.control_image)
-        
+
         arguments = {
             "control_image_url": f"data:image/png;base64,{control_image_base64}",
             "prompt": self.prompt,
@@ -454,7 +406,7 @@ class FluxProDepth(FALNode):
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "safety_tolerance": self.safety_tolerance,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -486,37 +438,29 @@ class FluxLoraCanny(FALNode):
 
     control_image: ImageRef = Field(
         default=ImageRef(),
-        description="The control image to generate the Canny edge map from"
+        description="The control image to generate the Canny edge map from",
     )
-    prompt: str = Field(
-        default="",
-        description="The prompt to generate an image from"
-    )
+    prompt: str = Field(default="", description="The prompt to generate an image from")
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     lora_scale: float = Field(
-        default=0.6,
-        description="The strength of the LoRA adaptation"
+        default=0.6, description="The strength of the LoRA adaptation"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         control_image_base64 = await context.image_to_base64(self.control_image)
-        
+
         arguments = {
             "control_image_url": f"data:image/png;base64,{control_image_base64}",
             "prompt": self.prompt,
@@ -524,7 +468,7 @@ class FluxLoraCanny(FALNode):
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "lora_scale": self.lora_scale,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -557,37 +501,29 @@ class FluxLoraDepth(FALNode):
 
     control_image: ImageRef = Field(
         default=ImageRef(),
-        description="The control image to generate the depth map from"
+        description="The control image to generate the depth map from",
     )
-    prompt: str = Field(
-        default="",
-        description="The prompt to generate an image from"
-    )
+    prompt: str = Field(default="", description="The prompt to generate an image from")
     image_size: ImageSizePreset = Field(
         default=ImageSizePreset.LANDSCAPE_4_3,
-        description="The size of the generated image"
+        description="The size of the generated image",
     )
     num_inference_steps: int = Field(
-        default=28,
-        ge=1,
-        description="The number of inference steps to perform"
+        default=28, ge=1, description="The number of inference steps to perform"
     )
     guidance_scale: float = Field(
-        default=3.5,
-        description="How closely the model should stick to your prompt"
+        default=3.5, description="How closely the model should stick to your prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
     lora_scale: float = Field(
-        default=0.6,
-        description="The strength of the LoRA adaptation"
+        default=0.6, description="The strength of the LoRA adaptation"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         control_image_base64 = await context.image_to_base64(self.control_image)
-        
+
         arguments = {
             "control_image_url": f"data:image/png;base64,{control_image_base64}",
             "prompt": self.prompt,
@@ -595,7 +531,7 @@ class FluxLoraDepth(FALNode):
             "num_inference_steps": self.num_inference_steps,
             "guidance_scale": self.guidance_scale,
             "lora_scale": self.lora_scale,
-            "output_format": "png"
+            "output_format": "png",
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -616,6 +552,7 @@ class FluxLoraDepth(FALNode):
 
 # ... existing code ...
 
+
 class IdeogramV2Edit(FALNode):
     """Transform existing images with Ideogram V2's editing capabilities. Modify, adjust, and refine images while maintaining high fidelity and realistic outputs with precise prompt control.
     image, editing, transformation, fidelity, control
@@ -626,42 +563,34 @@ class IdeogramV2Edit(FALNode):
     - Refine and enhance image details
     - Generate contextual image edits
     """
-    
+
     prompt: str = Field(
-        default="",
-        description="The prompt to fill the masked part of the image"
+        default="", description="The prompt to fill the masked part of the image"
     )
-    image: ImageRef = Field(
-        default=ImageRef(),
-        description="The image to edit"
-    )
-    mask: ImageRef = Field(
-        default=ImageRef(),
-        description="The mask for editing"
-    )
+    image: ImageRef = Field(default=ImageRef(), description="The image to edit")
+    mask: ImageRef = Field(default=ImageRef(), description="The mask for editing")
     style: str = Field(
         default="auto",
-        description="Style of generated image (auto, general, realistic, design, render_3D, anime)"
+        description="Style of generated image (auto, general, realistic, design, render_3D, anime)",
     )
     expand_prompt: bool = Field(
         default=True,
-        description="Whether to expand the prompt with MagicPrompt functionality"
+        description="Whether to expand the prompt with MagicPrompt functionality",
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
         mask_base64 = await context.image_to_base64(self.mask)
-        
+
         arguments = {
             "prompt": self.prompt,
             "image_url": f"data:image/png;base64,{image_base64}",
             "mask_url": f"data:image/png;base64,{mask_base64}",
             "style": self.style,
-            "expand_prompt": self.expand_prompt
+            "expand_prompt": self.expand_prompt,
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -679,6 +608,7 @@ class IdeogramV2Edit(FALNode):
     def get_basic_fields(cls):
         return ["prompt", "image", "mask"]
 
+
 class IdeogramV2Remix(FALNode):
     """Reimagine existing images with Ideogram V2's remix feature. Create variations and adaptations while preserving core elements and adding new creative directions through prompt guidance.
     image, remix, variation, creativity, adaptation
@@ -691,45 +621,36 @@ class IdeogramV2Remix(FALNode):
     - Generate alternative interpretations
     """
 
-    prompt: str = Field(
-        default="",
-        description="The prompt to remix the image with"
-    )
-    image: ImageRef = Field(
-        default=ImageRef(),
-        description="The image to remix"
-    )
+    prompt: str = Field(default="", description="The prompt to remix the image with")
+    image: ImageRef = Field(default=ImageRef(), description="The image to remix")
     aspect_ratio: str = Field(
-        default="1:1",
-        description="The aspect ratio of the generated image"
+        default="1:1", description="The aspect ratio of the generated image"
     )
     strength: float = Field(
-        default=0.8,
-        description="Strength of the input image in the remix"
+        default=0.8, description="Strength of the input image in the remix"
     )
     expand_prompt: bool = Field(
         default=True,
-        description="Whether to expand the prompt with MagicPrompt functionality"
+        description="Whether to expand the prompt with MagicPrompt functionality",
     )
     style: str = Field(
         default="auto",
-        description="Style of generated image (auto, general, realistic, design, render_3D, anime)"
+        description="Style of generated image (auto, general, realistic, design, render_3D, anime)",
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "prompt": self.prompt,
             "image_url": f"data:image/png;base64,{image_base64}",
             "aspect_ratio": self.aspect_ratio,
             "strength": self.strength,
             "expand_prompt": self.expand_prompt,
-            "style": self.style
+            "style": self.style,
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -747,6 +668,7 @@ class IdeogramV2Remix(FALNode):
     def get_basic_fields(cls):
         return ["prompt", "image", "strength"]
 
+
 class BriaEraser(FALNode):
     """
     Bria Eraser enables precise removal of unwanted objects from images while maintaining high-quality outputs. Trained exclusively on licensed data for safe and risk-free commercial use.
@@ -760,27 +682,23 @@ class BriaEraser(FALNode):
     - Create clean, professional images
     """
 
-    image: ImageRef = Field(
-        default=ImageRef(),
-        description="Input image to erase from"
-    )
+    image: ImageRef = Field(default=ImageRef(), description="Input image to erase from")
     mask: ImageRef = Field(
-        default=ImageRef(),
-        description="The mask for areas to be cleaned"
+        default=ImageRef(), description="The mask for areas to be cleaned"
     )
     mask_type: str = Field(
         default="manual",
-        description="Type of mask - 'manual' for user-created or 'automatic' for algorithm-generated"
+        description="Type of mask - 'manual' for user-created or 'automatic' for algorithm-generated",
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
         mask_base64 = await context.image_to_base64(self.mask)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "mask_url": f"data:image/png;base64,{mask_base64}",
-            "mask_type": self.mask_type
+            "mask_type": self.mask_type,
         }
 
         res = await self.submit_request(
@@ -795,6 +713,7 @@ class BriaEraser(FALNode):
     def get_basic_fields(cls):
         return ["image", "mask"]
 
+
 class BriaProductShot(FALNode):
     """Place any product in any scenery with just a prompt or reference image while maintaining high integrity of the product. Trained exclusively on licensed data for safe and risk-free commercial use and optimized for eCommerce.
     image, product, placement, ecommerce
@@ -808,43 +727,43 @@ class BriaProductShot(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="The product image to be placed"
+        default=ImageRef(), description="The product image to be placed"
     )
     scene_description: str = Field(
-        default="",
-        description="Text description of the new scene/background"
+        default="", description="Text description of the new scene/background"
     )
     ref_image: ImageRef = Field(
-        default=ImageRef(),
-        description="Reference image for the new scene/background"
+        default=ImageRef(), description="Reference image for the new scene/background"
     )
     optimize_description: bool = Field(
-        default=True,
-        description="Whether to optimize the scene description"
+        default=True, description="Whether to optimize the scene description"
     )
     placement_type: str = Field(
         default="manual_placement",
-        description="How to position the product (original, automatic, manual_placement, manual_padding)"
+        description="How to position the product (original, automatic, manual_placement, manual_padding)",
     )
     manual_placement_selection: str = Field(
         default="bottom_center",
-        description="Specific placement position when using manual_placement"
+        description="Specific placement position when using manual_placement",
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        ref_image_base64 = await context.image_to_base64(self.ref_image) if self.ref_image.uri else ""
-        
+        ref_image_base64 = (
+            await context.image_to_base64(self.ref_image) if self.ref_image.uri else ""
+        )
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "scene_description": self.scene_description,
-            "ref_image_url": f"data:image/png;base64,{ref_image_base64}" if ref_image_base64 else "",
+            "ref_image_url": (
+                f"data:image/png;base64,{ref_image_base64}" if ref_image_base64 else ""
+            ),
             "optimize_description": self.optimize_description,
             "placement_type": self.placement_type,
             "manual_placement_selection": self.manual_placement_selection,
             "shot_size": [1000, 1000],
-            "fast": True
+            "fast": True,
         }
 
         res = await self.submit_request(
@@ -860,6 +779,7 @@ class BriaProductShot(FALNode):
     def get_basic_fields(cls):
         return ["image", "scene_description"]
 
+
 class BriaBackgroundReplace(FALNode):
     """Bria Background Replace allows for efficient swapping of backgrounds in images via text prompts or reference image, delivering realistic and polished results. Trained exclusively on licensed data for safe and risk-free commercial use.
     image, background, replacement, swap
@@ -873,42 +793,38 @@ class BriaBackgroundReplace(FALNode):
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="Input image to replace background"
+        default=ImageRef(), description="Input image to replace background"
     )
     ref_image: ImageRef = Field(
-        default=ImageRef(),
-        description="Reference image for the new background"
+        default=ImageRef(), description="Reference image for the new background"
     )
-    prompt: str = Field(
-        default="",
-        description="Prompt to generate new background"
-    )
+    prompt: str = Field(default="", description="Prompt to generate new background")
     negative_prompt: str = Field(
-        default="",
-        description="Negative prompt for background generation"
+        default="", description="Negative prompt for background generation"
     )
     refine_prompt: bool = Field(
-        default=True,
-        description="Whether to refine the prompt"
+        default=True, description="Whether to refine the prompt"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        ref_image_base64 = await context.image_to_base64(self.ref_image) if self.ref_image.uri else ""
-        
+        ref_image_base64 = (
+            await context.image_to_base64(self.ref_image) if self.ref_image.uri else ""
+        )
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
-            "ref_image_url": f"data:image/png;base64,{ref_image_base64}" if ref_image_base64 else "",
+            "ref_image_url": (
+                f"data:image/png;base64,{ref_image_base64}" if ref_image_base64 else ""
+            ),
             "prompt": self.prompt,
             "negative_prompt": self.negative_prompt,
             "refine_prompt": self.refine_prompt,
             "fast": True,
-            "num_images": 1
+            "num_images": 1,
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -921,10 +837,11 @@ class BriaBackgroundReplace(FALNode):
         assert res["images"] is not None
         assert len(res["images"]) > 0
         return ImageRef(uri=res["images"][0]["url"])
-    
+
     @classmethod
     def get_basic_fields(cls):
         return ["image", "prompt"]
+
 
 class BriaGenFill(FALNode):
     """Bria GenFill enables high-quality object addition or visual transformation. Trained exclusively on licensed data for safe and risk-free commercial use.
@@ -938,31 +855,22 @@ class BriaGenFill(FALNode):
     - Produce professional image modifications
     """
 
-    image: ImageRef = Field(
-        default=ImageRef(),
-        description="Input image to erase from"
-    )
+    image: ImageRef = Field(default=ImageRef(), description="Input image to erase from")
     mask: ImageRef = Field(
-        default=ImageRef(),
-        description="The mask for areas to be cleaned"
+        default=ImageRef(), description="The mask for areas to be cleaned"
     )
-    prompt: str = Field(
-        default="",
-        description="The prompt to generate images"
-    )
+    prompt: str = Field(default="", description="The prompt to generate images")
     negative_prompt: str = Field(
-        default="",
-        description="The negative prompt to use when generating images"
+        default="", description="The negative prompt to use when generating images"
     )
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
         mask_base64 = await context.image_to_base64(self.mask)
-        
+
         arguments: dict[str, Any] = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "mask_url": f"data:image/png;base64,{mask_base64}",
@@ -985,6 +893,7 @@ class BriaGenFill(FALNode):
     def get_basic_fields(cls):
         return ["image", "mask", "prompt"]
 
+
 class BriaExpand(FALNode):
     """Bria Expand expands images beyond their borders in high quality. Trained exclusively on licensed data for safe and risk-free commercial use.
     image, expansion, outpainting
@@ -996,62 +905,56 @@ class BriaExpand(FALNode):
     - Generate additional scene content
     """
 
-    image: ImageRef = Field(
-        default=ImageRef(),
-        description="The input image to expand"
-    )
+    image: ImageRef = Field(default=ImageRef(), description="The input image to expand")
     canvas_width: int = Field(
         default=1200,
-        description="The desired width of the final image, after the expansion"
+        description="The desired width of the final image, after the expansion",
     )
     canvas_height: int = Field(
         default=674,
-        description="The desired height of the final image, after the expansion"
+        description="The desired height of the final image, after the expansion",
     )
     original_image_width: int = Field(
         default=610,
-        description="The desired width of the original image, inside the full canvas"
+        description="The desired width of the original image, inside the full canvas",
     )
     original_image_height: int = Field(
         default=855,
-        description="The desired height of the original image, inside the full canvas"
+        description="The desired height of the original image, inside the full canvas",
     )
     original_image_x: int = Field(
         default=301,
-        description="The desired x-coordinate of the original image, inside the full canvas"
+        description="The desired x-coordinate of the original image, inside the full canvas",
     )
     original_image_y: int = Field(
         default=-66,
-        description="The desired y-coordinate of the original image, inside the full canvas"
+        description="The desired y-coordinate of the original image, inside the full canvas",
     )
     prompt: str = Field(
-        default="",
-        description="Text on which you wish to base the image expansion"
+        default="", description="Text on which you wish to base the image expansion"
     )
     negative_prompt: str = Field(
-        default="",
-        description="The negative prompt to use when generating images"
+        default="", description="The negative prompt to use when generating images"
     )
-    num_images: int = Field(
-        default=1,
-        description="Number of images to generate"
-    )
+    num_images: int = Field(default=1, description="Number of images to generate")
     seed: int = Field(
-        default=-1,
-        description="The same seed will output the same image every time"
+        default=-1, description="The same seed will output the same image every time"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
+
         arguments = {
             "image_url": f"data:image/png;base64,{image_base64}",
             "canvas_size": [self.canvas_width, self.canvas_height],
-            "original_image_size": [self.original_image_width, self.original_image_height],
+            "original_image_size": [
+                self.original_image_width,
+                self.original_image_height,
+            ],
             "original_image_location": [self.original_image_x, self.original_image_y],
             "prompt": self.prompt,
             "negative_prompt": self.negative_prompt,
-            "num_images": self.num_images
+            "num_images": self.num_images,
         }
         if self.seed != -1:
             arguments["seed"] = self.seed
@@ -1068,23 +971,21 @@ class BriaExpand(FALNode):
     def get_basic_fields(cls):
         return ["image", "canvas_width", "canvas_height", "prompt"]
 
+
 class BriaBackgroundRemove(FALNode):
     """
-    Bria RMBG 2.0 enables seamless removal of backgrounds from images, ideal for professional editing tasks. 
+    Bria RMBG 2.0 enables seamless removal of backgrounds from images, ideal for professional editing tasks.
     Trained exclusively on licensed data for safe and risk-free commercial use.
     """
 
     image: ImageRef = Field(
-        default=ImageRef(),
-        description="Input image to remove background from"
+        default=ImageRef(), description="Input image to remove background from"
     )
 
     async def process(self, context: ProcessingContext) -> ImageRef:
         image_base64 = await context.image_to_base64(self.image)
-        
-        arguments = {
-            "image_url": f"data:image/png;base64,{image_base64}"
-        }
+
+        arguments = {"image_url": f"data:image/png;base64,{image_base64}"}
 
         res = await self.submit_request(
             context=context,

--- a/src/nodetool/nodes/fal/speech_to_text.py
+++ b/src/nodetool/nodes/fal/speech_to_text.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import List
 import fal_client
 from pydantic import Field
 
@@ -15,7 +16,7 @@ class TaskEnum(str, Enum):
 class ChunkLevelEnum(str, Enum):
     SEGMENT = "segment"
     WORD = "word"
-    
+
 
 class LanguageEnum(str, Enum):
     AF = "af"
@@ -120,7 +121,6 @@ class LanguageEnum(str, Enum):
     ZH = "zh"
 
 
-
 class Whisper(FALNode):
     """
     Whisper is a model for speech transcription and translation that can transcribe audio in multiple languages and optionally translate to English.
@@ -135,60 +135,53 @@ class Whisper(FALNode):
     """
 
     audio: AudioRef = Field(
-        default=AudioRef(),
-        description="The audio file to transcribe"
+        default=AudioRef(), description="The audio file to transcribe"
     )
     task: TaskEnum = Field(
-        default=TaskEnum.TRANSCRIBE,
-        description="Task to perform on the audio file"
+        default=TaskEnum.TRANSCRIBE, description="Task to perform on the audio file"
     )
     language: LanguageEnum = Field(
         default=LanguageEnum.EN,
-        description="Language of the audio file. If not set, will be auto-detected"
+        description="Language of the audio file. If not set, will be auto-detected",
     )
     diarize: bool = Field(
-        default=False,
-        description="Whether to perform speaker diarization"
+        default=False, description="Whether to perform speaker diarization"
     )
     chunk_level: ChunkLevelEnum = Field(
         default=ChunkLevelEnum.SEGMENT,
-        description="Level of detail for timestamp chunks"
+        description="Level of detail for timestamp chunks",
     )
     num_speakers: int = Field(
         default=1,
         ge=1,
         le=10,
-        description="Number of speakers in the audio. If not set, will be auto-detected"
+        description="Number of speakers in the audio. If not set, will be auto-detected",
     )
-    batch_size: int = Field(
-        default=64,
-        description="Batch size for processing"
-    )
+    batch_size: int = Field(default=64, description="Batch size for processing")
     prompt: str = Field(
-        default="",
-        description="Optional prompt to guide the transcription"
+        default="", description="Optional prompt to guide the transcription"
     )
-    
+
     @classmethod
     def return_type(cls):
         return {
             "text": str,
             "chunks": list[dict],
             "inferred_languages": list[str],
-            "diarization_segments": list[dict]
+            "diarization_segments": list[dict],
         }
 
     async def process(self, context: ProcessingContext) -> dict:
         """
         Process the audio file using Whisper model.
-        
+
         Returns:
             dict: Contains transcription text, chunks, and optionally diarization segments
         """
         client: fal_client.AsyncClient = self.get_client(context)
         audio_bytes = await context.asset_to_bytes(self.audio)
         audio_url = await client.upload(audio_bytes, "audio/mp3")
-        
+
         arguments = {
             "audio_url": audio_url,
             "task": self.task.value,
@@ -214,7 +207,7 @@ class Whisper(FALNode):
             "text": result["text"],
             "chunks": result["chunks"],
             "inferred_languages": result["inferred_languages"],
-            "diarization_segments": result.get("diarization_segments", [])
+            "diarization_segments": result.get("diarization_segments", []),
         }
 
     @classmethod

--- a/src/nodetool/package_metadata/nodetool-fal.json
+++ b/src/nodetool/package_metadata/nodetool-fal.json
@@ -8,62 +8,77 @@
   "repo_id": "nodetool-ai/nodetool-fal",
   "nodes": [
     {
-      "title": "Bria Background Remove",
-      "description": "Bria RMBG 2.0 enables seamless removal of backgrounds from images, ideal for professional editing tasks. \n    Trained exclusively on licensed data for safe and risk-free commercial use.",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaBackgroundRemove",
-      "layout": "default",
+      "title": "F5 TTS",
+      "description": "F5 TTS (Text-to-Speech) model for generating natural-sounding speech from text with voice cloning capabilities.\n    audio, tts, voice-cloning, speech, synthesis, text-to-speech, tts, text-to-audio\n\n    Use cases:\n    - Generate natural speech from text\n    - Clone and replicate voices\n    - Create custom voiceovers\n    - Produce multilingual speech content\n    - Generate personalized audio content",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.F5TTS",
       "properties": [
         {
-          "name": "image",
+          "name": "gen_text",
           "type": {
-            "type": "image"
+            "type": "str"
           },
-          "default": {},
-          "title": "Image",
-          "description": "Input image to remove background from"
+          "default": "",
+          "title": "Gen Text",
+          "description": "The text to be converted to speech"
+        },
+        {
+          "name": "ref_audio_url",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Ref Audio Url",
+          "description": "URL of the reference audio file to clone the voice from"
+        },
+        {
+          "name": "ref_text",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Ref Text",
+          "description": "Optional reference text. If not provided, ASR will be used"
+        },
+        {
+          "name": "model_type",
+          "type": {
+            "type": "str"
+          },
+          "default": "F5-TTS",
+          "title": "Model Type",
+          "description": "Model type to use (F5-TTS or E2-TTS)"
+        },
+        {
+          "name": "remove_silence",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Remove Silence",
+          "description": "Whether to remove silence from the generated audio"
         }
       ],
       "outputs": [
         {
           "type": {
-            "type": "image"
+            "type": "audio"
           },
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
-        "image"
-      ],
-      "is_dynamic": false
+        "gen_text",
+        "ref_audio_url",
+        "model_type"
+      ]
     },
     {
-      "title": "Bria Background Replace",
-      "description": "Bria Background Replace allows for efficient swapping of backgrounds in images via text prompts or reference image, delivering realistic and polished results. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, background, replacement, swap\n\n    Use cases:\n    - Replace image backgrounds seamlessly\n    - Create professional photo compositions\n    - Generate custom scene settings\n    - Produce commercial-ready images\n    - Create consistent visual environments",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaBackgroundReplace",
-      "layout": "default",
+      "title": "MMAudio V2",
+      "description": "MMAudio V2 generates synchronized audio given text inputs. It can generate sounds described by a prompt.\n    audio, generation, synthesis, text-to-audio, synchronization\n\n    Use cases:\n    - Generate synchronized audio from text descriptions\n    - Create custom sound effects\n    - Produce ambient soundscapes\n    - Generate audio for multimedia content\n    - Create sound design elements",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.MMAudioV2",
       "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "Input image to replace background"
-        },
-        {
-          "name": "ref_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Ref Image",
-          "description": "Reference image for the new background"
-        },
         {
           "name": "prompt",
           "type": {
@@ -71,7 +86,7 @@
           },
           "default": "",
           "title": "Prompt",
-          "description": "Prompt to generate new background"
+          "description": "The prompt to generate the audio for"
         },
         {
           "name": "negative_prompt",
@@ -80,16 +95,45 @@
           },
           "default": "",
           "title": "Negative Prompt",
-          "description": "Negative prompt for background generation"
+          "description": "The negative prompt to avoid certain elements in the generated audio"
         },
         {
-          "name": "refine_prompt",
+          "name": "num_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 25,
+          "title": "Num Steps",
+          "description": "The number of steps to generate the audio for",
+          "min": 1.0
+        },
+        {
+          "name": "duration",
+          "type": {
+            "type": "float"
+          },
+          "default": 8.0,
+          "title": "Duration",
+          "description": "The duration of the audio to generate in seconds",
+          "min": 1.0
+        },
+        {
+          "name": "cfg_strength",
+          "type": {
+            "type": "float"
+          },
+          "default": 4.5,
+          "title": "Cfg Strength",
+          "description": "The strength of Classifier Free Guidance"
+        },
+        {
+          "name": "mask_away_clip",
           "type": {
             "type": "bool"
           },
-          "default": true,
-          "title": "Refine Prompt",
-          "description": "Whether to refine the prompt"
+          "default": false,
+          "title": "Mask Away Clip",
+          "description": "Whether to mask away the clip"
         },
         {
           "name": "seed",
@@ -98,1262 +142,28 @@
           },
           "default": -1,
           "title": "Seed",
-          "description": "The same seed will output the same image every time"
+          "description": "The same seed will output the same audio every time"
         }
       ],
       "outputs": [
         {
           "type": {
-            "type": "image"
+            "type": "audio"
           },
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "prompt"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Bria Eraser",
-      "description": "Bria Eraser enables precise removal of unwanted objects from images while maintaining high-quality outputs. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, removal, cleanup\n\n    Use cases:\n    - Remove unwanted objects from images\n    - Clean up image imperfections\n    - Prepare images for commercial use\n    - Remove distracting elements\n    - Create clean, professional images",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaEraser",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "Input image to erase from"
-        },
-        {
-          "name": "mask",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Mask",
-          "description": "The mask for areas to be cleaned"
-        },
-        {
-          "name": "mask_type",
-          "type": {
-            "type": "str"
-          },
-          "default": "manual",
-          "title": "Mask Type",
-          "description": "Type of mask - 'manual' for user-created or 'automatic' for algorithm-generated"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "mask"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Bria Expand",
-      "description": "Bria Expand expands images beyond their borders in high quality. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, expansion, outpainting\n\n    Use cases:\n    - Extend image boundaries seamlessly\n    - Create wider or taller compositions\n    - Expand images for different aspect ratios\n    - Generate additional scene content",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaExpand",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to expand"
-        },
-        {
-          "name": "canvas_width",
-          "type": {
-            "type": "int"
-          },
-          "default": 1200,
-          "title": "Canvas Width",
-          "description": "The desired width of the final image, after the expansion"
-        },
-        {
-          "name": "canvas_height",
-          "type": {
-            "type": "int"
-          },
-          "default": 674,
-          "title": "Canvas Height",
-          "description": "The desired height of the final image, after the expansion"
-        },
-        {
-          "name": "original_image_width",
-          "type": {
-            "type": "int"
-          },
-          "default": 610,
-          "title": "Original Image Width",
-          "description": "The desired width of the original image, inside the full canvas"
-        },
-        {
-          "name": "original_image_height",
-          "type": {
-            "type": "int"
-          },
-          "default": 855,
-          "title": "Original Image Height",
-          "description": "The desired height of the original image, inside the full canvas"
-        },
-        {
-          "name": "original_image_x",
-          "type": {
-            "type": "int"
-          },
-          "default": 301,
-          "title": "Original Image X",
-          "description": "The desired x-coordinate of the original image, inside the full canvas"
-        },
-        {
-          "name": "original_image_y",
-          "type": {
-            "type": "int"
-          },
-          "default": -66,
-          "title": "Original Image Y",
-          "description": "The desired y-coordinate of the original image, inside the full canvas"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "Text on which you wish to base the image expansion"
-        },
-        {
-          "name": "negative_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Negative Prompt",
-          "description": "The negative prompt to use when generating images"
-        },
-        {
-          "name": "num_images",
-          "type": {
-            "type": "int"
-          },
-          "default": 1,
-          "title": "Num Images",
-          "description": "Number of images to generate"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "canvas_width",
-        "canvas_height",
-        "prompt"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Bria Gen Fill",
-      "description": "Bria GenFill enables high-quality object addition or visual transformation. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, generation, filling, transformation\n\n    Use cases:\n    - Add new objects to existing images\n    - Transform specific image areas\n    - Generate contextual content\n    - Create seamless visual additions\n    - Produce professional image modifications",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaGenFill",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "Input image to erase from"
-        },
-        {
-          "name": "mask",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Mask",
-          "description": "The mask for areas to be cleaned"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate images"
-        },
-        {
-          "name": "negative_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Negative Prompt",
-          "description": "The negative prompt to use when generating images"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "mask",
-        "prompt"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Bria Product Shot",
-      "description": "Place any product in any scenery with just a prompt or reference image while maintaining high integrity of the product. Trained exclusively on licensed data for safe and risk-free commercial use and optimized for eCommerce.\n    image, product, placement, ecommerce\n\n    Use cases:\n    - Create professional product photography\n    - Generate contextual product shots\n    - Place products in custom environments\n    - Create eCommerce product listings\n    - Generate marketing visuals",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.BriaProductShot",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The product image to be placed"
-        },
-        {
-          "name": "scene_description",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Scene Description",
-          "description": "Text description of the new scene/background"
-        },
-        {
-          "name": "ref_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Ref Image",
-          "description": "Reference image for the new scene/background"
-        },
-        {
-          "name": "optimize_description",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Optimize Description",
-          "description": "Whether to optimize the scene description"
-        },
-        {
-          "name": "placement_type",
-          "type": {
-            "type": "str"
-          },
-          "default": "manual_placement",
-          "title": "Placement Type",
-          "description": "How to position the product (original, automatic, manual_placement, manual_padding)"
-        },
-        {
-          "name": "manual_placement_selection",
-          "type": {
-            "type": "str"
-          },
-          "default": "bottom_center",
-          "title": "Manual Placement Selection",
-          "description": "Specific placement position when using manual_placement"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "scene_description"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Dev Redux",
-      "description": "FLUX.1 [dev] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications.\n    image, transformation, style-transfer, development, flux\n\n    Use cases:\n    - Transform images with advanced controls\n    - Create customized image variations\n    - Apply precise style modifications",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxDevRedux",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to transform"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "enable_safety_checker",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Enable Safety Checker",
-          "description": "If true, the safety checker will be enabled"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "image_size",
-        "guidance_scale"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Lora Canny",
-      "description": "FLUX LoRA Canny enables precise control over composition and style through edge detection and LoRA-based guidance mechanisms.\n    image, edge, lora, style-transfer, control\n\n    Use cases:\n    - Generate stylized images with structural control\n    - Create edge-guided artistic transformations\n    - Apply custom styles while maintaining composition\n    - Produce consistent style variations",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxLoraCanny",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "control_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Control Image",
-          "description": "The control image to generate the Canny edge map from"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate an image from"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "lora_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 0.6,
-          "title": "Lora Scale",
-          "description": "The strength of the LoRA adaptation"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "control_image",
-        "prompt",
-        "image_size"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Lora Depth",
-      "description": "FLUX LoRA Depth enables precise control over composition and structure through depth map detection and LoRA-based guidance mechanisms.\n    image, depth, lora, structure, control\n\n    Use cases:\n    - Generate depth-aware stylized images\n    - Create 3D-conscious artistic transformations\n    - Maintain spatial relationships with custom styles\n    - Produce depth-consistent variations\n    - Generate images with controlled perspective",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxLoraDepth",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "control_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Control Image",
-          "description": "The control image to generate the depth map from"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate an image from"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "lora_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 0.6,
-          "title": "Lora Scale",
-          "description": "The strength of the LoRA adaptation"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "control_image",
-        "prompt",
-        "image_size"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Pro Canny",
-      "description": "FLUX.1 [pro] Canny enables precise control over composition, style, and structure through advanced edge detection and guidance mechanisms.\n    image, edge, composition, style, control\n\n    Use cases:\n    - Generate images with precise structural control\n    - Create artwork based on edge maps\n    - Transform sketches into detailed images\n    - Maintain specific compositional elements\n    - Generate variations with consistent structure",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxProCanny",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "control_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Control Image",
-          "description": "The control image to generate the Canny edge map from"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate an image from"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "safety_tolerance",
-          "type": {
-            "type": "str"
-          },
-          "default": "2",
-          "title": "Safety Tolerance",
-          "description": "Safety tolerance level (1-6, 1 being most strict)"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "control_image",
-        "prompt",
-        "image_size"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Pro Depth",
-      "description": "FLUX.1 [pro] Depth enables precise control over composition and structure through depth map detection and guidance mechanisms.\n    image, depth-map, composition, structure, control\n\n    Use cases:\n    - Generate images with controlled depth perception\n    - Create 3D-aware image transformations\n    - Maintain spatial relationships in generated images\n    - Produce images with accurate perspective\n    - Generate variations with consistent depth structure",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxProDepth",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "control_image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Control Image",
-          "description": "The control image to generate the depth map from"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate an image from"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "safety_tolerance",
-          "type": {
-            "type": "str"
-          },
-          "default": "2",
-          "title": "Safety Tolerance",
-          "description": "Safety tolerance level (1-6, 1 being most strict)"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "control_image",
-        "prompt",
-        "image_size"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Pro Fill",
-      "description": "FLUX.1 [pro] Fill is a high-performance endpoint that enables rapid transformation of existing images with inpainting/outpainting capabilities.\n    image, inpainting, outpainting, transformation, professional\n\n    Use cases:\n    - Fill in missing or masked parts of images\n    - Extend images beyond their original boundaries\n    - Remove and replace unwanted elements\n    - Create seamless image completions\n    - Generate context-aware image content",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxProFill",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to transform"
-        },
-        {
-          "name": "mask",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Mask",
-          "description": "The mask for inpainting"
-        },
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to fill the masked part of the image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "safety_tolerance",
-          "type": {
-            "type": "str"
-          },
-          "default": "2",
-          "title": "Safety Tolerance",
-          "description": "Safety tolerance level (1-6, 1 being most strict)"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "mask",
-        "prompt"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Pro Redux",
-      "description": "FLUX.1 [pro] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications.\n    image, transformation, style-transfer, flux\n\n    Use cases:\n    - Create professional image transformations\n    - Generate style transfers",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxProRedux",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to transform"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "safety_tolerance",
-          "type": {
-            "type": "str"
-          },
-          "default": "2",
-          "title": "Safety Tolerance",
-          "description": "Safety tolerance level (1-6, 1 being most strict)"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "image_size",
-        "guidance_scale"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Pro Ultra Redux",
-      "description": "FLUX1.1 [pro] ultra Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications with the core FLUX capabilities.\n    image, transformation, style-transfer, ultra, professional\n\n    Use cases:\n    - Apply precise image modifications\n    - Process images with maximum control",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxProUltraRedux",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to transform"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 28,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "guidance_scale",
-          "type": {
-            "type": "float"
-          },
-          "default": 3.5,
-          "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "safety_tolerance",
-          "type": {
-            "type": "str"
-          },
-          "default": "2",
-          "title": "Safety Tolerance",
-          "description": "Safety tolerance level (1-6, 1 being most strict)"
-        },
-        {
-          "name": "image_prompt_strength",
-          "type": {
-            "type": "float"
-          },
-          "default": 0.1,
-          "title": "Image Prompt Strength",
-          "description": "The strength of the image prompt, between 0 and 1"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "image_size",
-        "guidance_scale"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Flux Schnell Redux",
-      "description": "FLUX.1 [schnell] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications with the core FLUX capabilities.\n    image, transformation, style-transfer, fast, flux\n\n    Use cases:\n    - Transform images with style transfers\n    - Apply artistic modifications to photos\n    - Create image variations",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.FluxSchnellRedux",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The input image to transform"
-        },
-        {
-          "name": "image_size",
-          "type": {
-            "type": "enum",
-            "values": [
-              "square_hd",
-              "square",
-              "portrait_4_3",
-              "portrait_16_9",
-              "landscape_4_3",
-              "landscape_16_9"
-            ],
-            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
-          },
-          "default": "landscape_4_3",
-          "title": "Image Size",
-          "description": "The size of the generated image"
-        },
-        {
-          "name": "num_inference_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 4,
-          "title": "Num Inference Steps",
-          "description": "The number of inference steps to perform",
-          "min": 1.0
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        },
-        {
-          "name": "enable_safety_checker",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Enable Safety Checker",
-          "description": "If true, the safety checker will be enabled"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "image",
-        "image_size",
-        "num_inference_steps"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Ideogram V 2 Edit",
-      "description": "Transform existing images with Ideogram V2's editing capabilities. Modify, adjust, and refine images while maintaining high fidelity and realistic outputs with precise prompt control.\n    image, editing, transformation, fidelity, control\n\n    Use cases:\n    - Edit specific parts of images with precision\n    - Create targeted image modifications\n    - Refine and enhance image details\n    - Generate contextual image edits",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.IdeogramV2Edit",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to fill the masked part of the image"
-        },
-        {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The image to edit"
-        },
-        {
-          "name": "mask",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Mask",
-          "description": "The mask for editing"
-        },
-        {
-          "name": "style",
-          "type": {
-            "type": "str"
-          },
-          "default": "auto",
-          "title": "Style",
-          "description": "Style of generated image (auto, general, realistic, design, render_3D, anime)"
-        },
-        {
-          "name": "expand_prompt",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Expand Prompt",
-          "description": "Whether to expand the prompt with MagicPrompt functionality"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "image"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
-        "image",
-        "mask"
-      ],
-      "is_dynamic": false
+        "duration",
+        "num_steps"
+      ]
     },
     {
-      "title": "Ideogram V 2 Remix",
-      "description": "Reimagine existing images with Ideogram V2's remix feature. Create variations and adaptations while preserving core elements and adding new creative directions through prompt guidance.\n    image, remix, variation, creativity, adaptation\n\n    Use cases:\n    - Create artistic variations of images\n    - Generate style-transferred versions\n    - Produce creative image adaptations\n    - Transform images while preserving key elements\n    - Generate alternative interpretations",
-      "namespace": "fal.image_to_image",
-      "node_type": "fal.image_to_image.IdeogramV2Remix",
-      "layout": "default",
+      "title": "Stable Audio",
+      "description": "Stable Audio generates audio from text prompts. Open source text-to-audio model from fal.ai.\n    audio, generation, synthesis, text-to-audio, open-source\n\n    Use cases:\n    - Generate custom audio content from text\n    - Create background music and sounds\n    - Produce audio assets for projects\n    - Generate sound effects\n    - Create experimental audio content",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.StableAudio",
       "properties": [
         {
           "name": "prompt",
@@ -1362,86 +172,69 @@
           },
           "default": "",
           "title": "Prompt",
-          "description": "The prompt to remix the image with"
+          "description": "The prompt to generate the audio from"
         },
         {
-          "name": "image",
-          "type": {
-            "type": "image"
-          },
-          "default": {},
-          "title": "Image",
-          "description": "The image to remix"
-        },
-        {
-          "name": "aspect_ratio",
-          "type": {
-            "type": "str"
-          },
-          "default": "1:1",
-          "title": "Aspect Ratio",
-          "description": "The aspect ratio of the generated image"
-        },
-        {
-          "name": "strength",
-          "type": {
-            "type": "float"
-          },
-          "default": 0.8,
-          "title": "Strength",
-          "description": "Strength of the input image in the remix"
-        },
-        {
-          "name": "expand_prompt",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Expand Prompt",
-          "description": "Whether to expand the prompt with MagicPrompt functionality"
-        },
-        {
-          "name": "style",
-          "type": {
-            "type": "str"
-          },
-          "default": "auto",
-          "title": "Style",
-          "description": "Style of generated image (auto, general, realistic, design, render_3D, anime)"
-        },
-        {
-          "name": "seed",
+          "name": "seconds_start",
           "type": {
             "type": "int"
           },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same image every time"
+          "default": 0,
+          "title": "Seconds Start",
+          "description": "The start point of the audio clip to generate"
+        },
+        {
+          "name": "seconds_total",
+          "type": {
+            "type": "int"
+          },
+          "default": 30,
+          "title": "Seconds Total",
+          "description": "The duration of the audio clip to generate in seconds"
+        },
+        {
+          "name": "steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 100,
+          "title": "Steps",
+          "description": "The number of steps to denoise the audio for"
         }
       ],
       "outputs": [
         {
           "type": {
-            "type": "image"
+            "type": "audio"
           },
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
-        "image",
-        "strength"
-      ],
-      "is_dynamic": false
+        "seconds_total",
+        "steps"
+      ]
+    },
+    {
+      "title": "FAL",
+      "description": "FAL Node for interacting with FAL AI services.\n    Provides methods to submit and handle API requests to FAL endpoints.",
+      "namespace": "fal.fal_node",
+      "node_type": "fal.fal_node.FAL",
+      "outputs": [
+        {
+          "type": {
+            "type": "any"
+          },
+          "name": "output"
+        }
+      ]
     },
     {
       "title": "Aura Flow V 03",
       "description": "AuraFlow v0.3 is an open-source flow-based text-to-image generation model that achieves state-of-the-art results on GenEval.\n    image, generation, flow-based, text-to-image, txt2img\n\n    Use cases:\n    - Generate high-quality images\n    - Create artistic visualizations",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.AuraFlowV03",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -1508,21 +301,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "guidance_scale",
         "num_inference_steps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Bria V 1",
       "description": "Bria's Text-to-Image model, trained exclusively on licensed data for safe and risk-free commercial use.\n    Features exceptional image quality and commercial licensing safety.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.BriaV1",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -1632,21 +421,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Bria V 1 Fast",
       "description": "Bria's Text-to-Image model with perfect harmony of latency and quality.\n    Trained exclusively on licensed data for safe and risk-free commercial use.\n    Features faster inference times while maintaining high image quality.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.BriaV1Fast",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -1756,21 +541,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Bria V 1 HD",
       "description": "Bria's Text-to-Image model for HD images. Trained exclusively on licensed data for safe and risk-free commercial use. Features exceptional image quality and commercial licensing safety.\n    image, generation, hd, text-to-image, txt2img\n\n    Use cases:\n    - Create commercial marketing materials\n    - Generate licensed artwork\n    - Produce high-definition visuals\n    - Design professional content\n    - Create legally safe visual assets",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.BriaV1HD",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -1880,21 +661,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Diffusion Edge",
       "description": "Diffusion Edge is a diffusion-based high-quality edge detection model that generates\n    edge maps from input images.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.DiffusionEdge",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -1914,19 +691,15 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast LCMDiffusion",
       "description": "Fast Latent Consistency Models (v1.5/XL) Text to Image runs SDXL at the speed of light,\n    enabling rapid and high-quality image generation.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FastLCMDiffusion",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2075,21 +848,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "model_name",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast Lightning SDXL",
       "description": "Stable Diffusion XL Lightning Text to Image runs SDXL at the speed of light, enabling\n    ultra-fast high-quality image generation.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FastLightningSDXL",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2165,21 +934,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "num_inference_steps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast SDXL",
       "description": "Fast SDXL is a high-performance text-to-image model that runs SDXL at exceptional speeds\n    while maintaining high-quality output.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FastSDXL",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2296,21 +1061,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast SDXLControl Net Canny",
       "description": "Fast SDXL ControlNet Canny is a model that generates images using ControlNet with SDXL.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FastSDXLControlNetCanny",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2403,21 +1164,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "control_image",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast Turbo Diffusion",
       "description": "Fast Turbo Diffusion runs SDXL at exceptional speeds while maintaining high-quality output.\n    Supports both SDXL Turbo and SD Turbo models for ultra-fast image generation.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FastTurboDiffusion",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2524,21 +1281,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "model_name",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Dev",
       "description": "FLUX.1 [dev] is a 12 billion parameter flow transformer that generates high-quality images from text.\n    It is suitable for personal and commercial use.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxDev",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2623,21 +1376,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Dev Image To Image",
       "description": "FLUX.1 [dev] Image-to-Image is a high-performance endpoint that enables rapid transformation\n    of existing images, delivering high-quality style transfers and image modifications with\n    the core FLUX capabilities.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxDevImageToImage",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2712,21 +1461,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image",
         "strength"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux General",
       "description": "FLUX.1 [dev] with Controlnets and Loras is a versatile text-to-image model that supports multiple AI extensions including LoRA, ControlNet conditioning, and IP-Adapter integration, enabling comprehensive control over image generation through various guidance methods.\n    image, generation, controlnet, lora, ip-adapter, text-to-image, txt2img\n\n    Use cases:\n    - Create controlled image generations\n    - Apply multiple AI extensions\n    - Generate guided visual content\n    - Produce customized artwork\n    - Design with precise control",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxGeneral",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2868,21 +1613,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Lora",
       "description": "FLUX.1 [dev] with LoRAs is a text-to-image model that supports LoRA adaptations, enabling rapid and high-quality image generation with pre-trained LoRA weights for personalization, specific styles, brand identities, and product-specific outputs.\n    image, generation, lora, personalization, style-transfer, text-to-image, txt2img\n\n    Use cases:\n    - Create brand-specific visuals\n    - Generate custom styled images\n    - Adapt existing styles to new content\n    - Produce personalized artwork\n    - Design consistent visual identities",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxLora",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -2971,21 +1712,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "loras"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Lora Inpainting",
       "description": "FLUX.1 [dev] Inpainting with LoRAs is a text-to-image model that supports inpainting and LoRA adaptations,\n    enabling rapid and high-quality image inpainting using pre-trained LoRA weights for personalization,\n    specific styles, brand identities, and product-specific outputs.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxLoraInpainting",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3085,22 +1822,18 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image",
         "mask",
         "loras"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Lora TTI",
       "description": "FLUX.1 with LoRAs is a text-to-image model that supports LoRA adaptations,\n    enabling high-quality image generation with customizable LoRA weights for\n    personalization, specific styles, and brand identities.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxLoraTTI",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3226,21 +1959,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "model_name",
         "loras"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Schnell",
       "description": "FLUX.1 [schnell] is a 12 billion parameter flow transformer that generates high-quality images\n    from text in 1 to 4 steps, suitable for personal and commercial use.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxSchnell",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3316,21 +2045,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "num_inference_steps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux Subject",
       "description": "FLUX.1 Subject is a super fast endpoint for the FLUX.1 [schnell] model with subject input capabilities, enabling rapid and high-quality image generation for personalization, specific styles, brand identities, and product-specific outputs.\n    image, generation, subject-driven, personalization, fast, text-to-image, txt2img\n\n    Use cases:\n    - Create variations of existing subjects\n    - Generate personalized product images\n    - Design brand-specific visuals\n    - Produce custom character artwork\n    - Create subject-based illustrations",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxSubject",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3414,21 +2139,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image",
         "image_size"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux V 1 Pro",
       "description": "FLUX1.1 [pro] is an enhanced version of FLUX.1 [pro], improved image generation capabilities, delivering superior composition, detail, and artistic fidelity compared to its predecessor.\n    image, generation, composition, detail, artistic, text-to-image, txt2img\n\n    Use cases:\n    - Generate high-fidelity artwork\n    - Create detailed illustrations\n    - Design complex compositions\n    - Produce artistic renderings\n    - Generate professional visuals",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxV1Pro",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3497,21 +2218,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux V 1 Pro New",
       "description": "FLUX.1 [pro] new is an accelerated version of FLUX.1 [pro], maintaining professional-grade\n    image quality while delivering significantly faster generation speeds.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxV1ProNew",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3600,21 +2317,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Flux V 1 Pro Ultra",
       "description": "FLUX1.1 [ultra] is the latest and most advanced version of FLUX.1 [pro],\n    featuring cutting-edge improvements in image generation, delivering unparalleled\n    composition, detail, and artistic fidelity.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.FluxV1ProUltra",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3683,21 +2396,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fooocus",
       "description": "Fooocus is a text-to-image model with default parameters and automated optimizations\n    for quality improvements.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.Fooocus",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3885,21 +2594,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "styles"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Hyper SDXL",
       "description": "Hyper SDXL is a hyper-charged version of SDXL that delivers exceptional performance and creativity\n    while maintaining high-quality output and ultra-fast generation speeds.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.HyperSDXL",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -3994,21 +2699,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "num_inference_steps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Ideogram V 2",
       "description": "Ideogram V2 is a state-of-the-art image generation model optimized for commercial and creative use, featuring exceptional typography handling and realistic outputs.\n    image, generation, ai, typography, realistic, text-to-image, txt2img\n\n    Use cases:\n    - Create commercial artwork and designs\n    - Generate realistic product visualizations\n    - Design marketing materials with text\n    - Produce high-quality illustrations\n    - Create brand assets and logos",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.IdeogramV2",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4098,21 +2799,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "aspect_ratio",
         "style"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Ideogram V 2 Turbo",
       "description": "Accelerated image generation with Ideogram V2 Turbo. Create high-quality visuals, posters,\n    and logos with enhanced speed while maintaining Ideogram's signature quality.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.IdeogramV2Turbo",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4202,21 +2899,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "aspect_ratio",
         "style"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Illusion Diffusion",
       "description": "Illusion Diffusion is a model that creates illusions conditioned on an input image.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.IllusionDiffusion",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4300,21 +2993,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Imagen 4 Preview",
-      "description": "Imagen 4 is an advanced text-to-image model providing high quality and\n    detailed visuals with strong prompt understanding.\n    image, generation, diffusion, text-to-image, txt2img\n\n    Use cases:\n    - Create marketing and product visuals\n    - Generate concept art and illustrations\n    - Produce photorealistic images from descriptions\n    - Experiment with advanced diffusion capabilities\n    - Rapidly prototype visual ideas",
+      "description": "Imagen 4 Preview is the next iteration of Google's Imagen series, offering\n    high quality text-to-image generation with strong prompt adherence and\n    improved realism.\n    image, generation, google, text-to-image, txt2img\n\n    Use cases:\n    - Generate photorealistic artwork and designs\n    - Create marketing and product visuals\n    - Produce concept art or storyboards\n    - Explore creative ideas with high fidelity\n    - Rapid prototyping of imagery",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.Imagen4Preview",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4332,7 +3021,32 @@
           },
           "default": "",
           "title": "Negative Prompt",
-          "description": "Use it to address details that you don't want in the image"
+          "description": "Elements to avoid in the generated image"
+        },
+        {
+          "name": "aspect_ratio",
+          "type": {
+            "type": "enum",
+            "values": [
+              "10:16",
+              "16:10",
+              "9:16",
+              "16:9",
+              "4:3",
+              "3:4",
+              "1:1",
+              "1:3",
+              "3:1",
+              "3:2",
+              "2:3",
+              "4:5",
+              "5:4"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.AspectRatio"
+          },
+          "default": "1:1",
+          "title": "Aspect Ratio",
+          "description": "The aspect ratio of the generated image"
         },
         {
           "name": "image_size",
@@ -4369,7 +3083,7 @@
           },
           "default": 5.0,
           "title": "Guidance Scale",
-          "description": "How closely the model should stick to your prompt"
+          "description": "How closely the model should follow the prompt"
         },
         {
           "name": "num_images",
@@ -4408,21 +3122,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
-        "image_size",
+        "aspect_ratio",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "LCMDiffusion",
       "description": "Latent Consistency Models (SDXL & SDv1.5) Text to Image produces high-quality images\n    with minimal inference steps.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.LCMDiffusion",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4520,21 +3230,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "model",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Luma Photon",
       "description": "Luma Photon is a creative and personalizable text-to-image model that brings a step-function\n    change in the cost of high-quality image generation, optimized for creatives.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.LumaPhoton",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4573,20 +3279,16 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Luma Photon Flash",
       "description": "Luma Photon Flash is the most creative, personalizable, and intelligent visual model for creatives,\n    bringing a step-function change in the cost of high-quality image generation with faster inference times.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.LumaPhotonFlash",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4625,20 +3327,16 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Omni Gen V 1",
       "description": "OmniGen is a unified image generation model that can generate a wide range of images from multi-modal prompts. It can be used for various tasks such as Image Editing, Personalized Image Generation, Virtual Try-On, Multi Person Generation and more!\n    image, generation, multi-modal, editing, personalization, text-to-image, txt2img\n\n    Use cases:\n    - Edit and modify existing images\n    - Create personalized visual content\n    - Generate virtual try-on images\n    - Create multi-person compositions\n    - Combine multiple images creatively",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.OmniGenV1",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4750,21 +3448,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "input_image_1",
         "image_size"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Playground V 25",
       "description": "Playground v2.5 is a state-of-the-art open-source model that excels in aesthetic quality\n    for text-to-image generation.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.PlaygroundV25",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4839,21 +3533,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Recraft 20 B",
       "description": "Recraft 20B is a new and affordable text-to-image model that delivers state-of-the-art results.\n     image, generation, efficient, text-to-image, txt2img\n\n    Use cases:\n    - Generate cost-effective visuals\n    - Create high-quality images\n    - Produce professional artwork\n    - Design marketing materials\n    - Generate commercial content",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.Recraft20B",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -4952,21 +3642,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "style"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Recraft V 3",
       "description": "Recraft V3 is a text-to-image model with the ability to generate long texts, vector art, images in brand style, and much more.\n    image, text",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.RecraftV3",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5065,21 +3751,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "style"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Sana V 1",
       "description": "Sana can synthesize high-resolution, high-quality images with strong text-image alignment at a remarkably fast speed, with the ability to generate 4K images in less than a second.\n    image, generation, high-resolution, fast, text-alignment, text-to-image, txt2img\n\n    Use cases:\n    - Generate 4K quality images\n    - Create high-resolution artwork\n    - Produce rapid visual prototypes\n    - Design detailed illustrations\n    - Generate precise text-aligned visuals",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.SanaV1",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5173,21 +3855,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "image_size",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Stable Cascade",
       "description": "Stable Cascade is a state-of-the-art text-to-image model that generates images on a smaller & cheaper\n    latent space while maintaining high quality output.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.StableCascade",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5288,21 +3966,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Stable Diffusion V 35 Large",
       "description": "Stable Diffusion 3.5 Large is a Multimodal Diffusion Transformer (MMDiT) text-to-image model that features\n    improved performance in image quality, typography, complex prompt understanding, and resource-efficiency.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.StableDiffusionV35Large",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5386,21 +4060,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Stable Diffusion V 3 Medium",
       "description": "Stable Diffusion 3 Medium (Text to Image) is a Multimodal Diffusion Transformer (MMDiT) model\n    that improves image quality, typography, prompt understanding, and efficiency.",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.StableDiffusionV3Medium",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5503,21 +4173,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "negative_prompt",
         "guidance_scale"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Switti",
       "description": "Switti is a scale-wise transformer for fast text-to-image generation that outperforms existing T2I AR models and competes with state-of-the-art T2I diffusion models while being faster than distilled diffusion models.\n    image, generation, fast, transformer, efficient, text-to-image, txt2img\n\n    Use cases:\n    - Rapid image prototyping\n    - Real-time image generation\n    - Quick visual concept testing\n    - Fast artistic visualization\n    - Efficient batch image creation",
       "namespace": "fal.text_to_image",
       "node_type": "fal.text_to_image.Switti",
-      "layout": "default",
       "properties": [
         {
           "name": "prompt",
@@ -5636,108 +4302,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "prompt",
         "guidance_scale",
         "negative_prompt"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "FAL",
-      "description": "FAL Node for interacting with FAL AI services.\n    Provides methods to submit and handle API requests to FAL endpoints.",
-      "namespace": "fal.fal_node",
-      "node_type": "fal.fal_node.FAL",
-      "layout": "default",
-      "properties": [],
-      "outputs": [
-        {
-          "type": {
-            "type": "any"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [],
-      "is_dynamic": false
-    },
-    {
-      "title": "Any LLM",
-      "description": "Use any large language model from a selected catalogue (powered by OpenRouter).\n    Supports various models including Claude 3, Gemini, Llama, and GPT-4.\n    llm, text, generation, ai, language\n\n    Use cases:\n    - Generate natural language responses\n    - Create conversational AI interactions\n    - Process and analyze text content\n    - Generate creative writing\n    - Assist with problem-solving tasks",
-      "namespace": "fal.llm",
-      "node_type": "fal.llm.AnyLLM",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to send to the language model"
-        },
-        {
-          "name": "system_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "System Prompt",
-          "description": "Optional system prompt to provide context or instructions"
-        },
-        {
-          "name": "model",
-          "type": {
-            "type": "enum",
-            "values": [
-              "anthropic/claude-3.5-sonnet",
-              "anthropic/claude-3-5-haiku",
-              "anthropic/claude-3-haiku",
-              "google/gemini-pro-1.5",
-              "google/gemini-flash-1.5",
-              "google/gemini-flash-1.5-8b",
-              "meta-llama/llama-3.2-1b-instruct",
-              "meta-llama/llama-3.2-3b-instruct",
-              "meta-llama/llama-3.1-8b-instruct",
-              "meta-llama/llama-3.1-70b-instruct",
-              "openai/gpt-4o-mini",
-              "openai/gpt-4o"
-            ],
-            "type_name": "nodetool.nodes.fal.llm.ModelEnum"
-          },
-          "default": "google/gemini-flash-1.5",
-          "title": "Model",
-          "description": "The language model to use for the completion"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "str"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "prompt",
-        "model",
-        "system_prompt"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Whisper",
       "description": "Whisper is a model for speech transcription and translation that can transcribe audio in multiple languages and optionally translate to English.\n    speech, audio, transcription, translation, transcribe, translate, multilingual, speech-to-text, audio-to-text\n\n    Use cases:\n    - Transcribe spoken content to text\n    - Translate speech to English\n    - Generate subtitles and captions\n    - Create text records of audio content\n    - Analyze multilingual audio content",
       "namespace": "fal.speech_to_text",
       "node_type": "fal.speech_to_text.Whisper",
-      "layout": "default",
       "properties": [
         {
           "name": "audio",
@@ -5968,242 +4543,17 @@
           "name": "diarization_segments"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "audio",
         "task",
         "diarize"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "F5 TTS",
-      "description": "F5 TTS (Text-to-Speech) model for generating natural-sounding speech from text with voice cloning capabilities.\n    audio, tts, voice-cloning, speech, synthesis, text-to-speech, tts, text-to-audio\n\n    Use cases:\n    - Generate natural speech from text\n    - Clone and replicate voices\n    - Create custom voiceovers\n    - Produce multilingual speech content\n    - Generate personalized audio content",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.F5TTS",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "gen_text",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Gen Text",
-          "description": "The text to be converted to speech"
-        },
-        {
-          "name": "ref_audio_url",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Ref Audio Url",
-          "description": "URL of the reference audio file to clone the voice from"
-        },
-        {
-          "name": "ref_text",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Ref Text",
-          "description": "Optional reference text. If not provided, ASR will be used"
-        },
-        {
-          "name": "model_type",
-          "type": {
-            "type": "str"
-          },
-          "default": "F5-TTS",
-          "title": "Model Type",
-          "description": "Model type to use (F5-TTS or E2-TTS)"
-        },
-        {
-          "name": "remove_silence",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Remove Silence",
-          "description": "Whether to remove silence from the generated audio"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "gen_text",
-        "ref_audio_url",
-        "model_type"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "MMAudio V2",
-      "description": "MMAudio V2 generates synchronized audio given text inputs. It can generate sounds described by a prompt.\n    audio, generation, synthesis, text-to-audio, synchronization\n\n    Use cases:\n    - Generate synchronized audio from text descriptions\n    - Create custom sound effects\n    - Produce ambient soundscapes\n    - Generate audio for multimedia content\n    - Create sound design elements",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.MMAudioV2",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate the audio for"
-        },
-        {
-          "name": "negative_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Negative Prompt",
-          "description": "The negative prompt to avoid certain elements in the generated audio"
-        },
-        {
-          "name": "num_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 25,
-          "title": "Num Steps",
-          "description": "The number of steps to generate the audio for",
-          "min": 1.0
-        },
-        {
-          "name": "duration",
-          "type": {
-            "type": "float"
-          },
-          "default": 8.0,
-          "title": "Duration",
-          "description": "The duration of the audio to generate in seconds",
-          "min": 1.0
-        },
-        {
-          "name": "cfg_strength",
-          "type": {
-            "type": "float"
-          },
-          "default": 4.5,
-          "title": "Cfg Strength",
-          "description": "The strength of Classifier Free Guidance"
-        },
-        {
-          "name": "mask_away_clip",
-          "type": {
-            "type": "bool"
-          },
-          "default": false,
-          "title": "Mask Away Clip",
-          "description": "Whether to mask away the clip"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same audio every time"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "prompt",
-        "duration",
-        "num_steps"
-      ],
-      "is_dynamic": false
-    },
-    {
-      "title": "Stable Audio",
-      "description": "Stable Audio generates audio from text prompts. Open source text-to-audio model from fal.ai.\n    audio, generation, synthesis, text-to-audio, open-source\n\n    Use cases:\n    - Generate custom audio content from text\n    - Create background music and sounds\n    - Produce audio assets for projects\n    - Generate sound effects\n    - Create experimental audio content",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.StableAudio",
-      "layout": "default",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate the audio from"
-        },
-        {
-          "name": "seconds_start",
-          "type": {
-            "type": "int"
-          },
-          "default": 0,
-          "title": "Seconds Start",
-          "description": "The start point of the audio clip to generate"
-        },
-        {
-          "name": "seconds_total",
-          "type": {
-            "type": "int"
-          },
-          "default": 30,
-          "title": "Seconds Total",
-          "description": "The duration of the audio clip to generate in seconds"
-        },
-        {
-          "name": "steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 100,
-          "title": "Steps",
-          "description": "The number of steps to denoise the audio for"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "the_model_info": {},
-      "recommended_models": [],
-      "basic_fields": [
-        "prompt",
-        "seconds_total",
-        "steps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "AMTInterpolation",
       "description": "Interpolate between image frames to create smooth video transitions. Supports configurable FPS and recursive interpolation passes for higher quality results.\n    video, interpolation, transitions, frames, smoothing, img2vid, image-to-video\n\n    Use cases:\n    - Create smooth frame transitions\n    - Generate fluid animations\n    - Enhance video frame rates\n    - Produce slow-motion effects\n    - Create seamless video blends",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.AMTInterpolation",
-      "layout": "default",
       "properties": [
         {
           "name": "frames",
@@ -6249,20 +4599,16 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "frames",
         "output_fps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Cog Video X",
       "description": "Generate videos from images using CogVideoX-5B. Features high-quality motion synthesis with configurable parameters for fine-tuned control over the output.\n    video, generation, motion, synthesis, control, img2vid, image-to-video\n\n    Use cases:\n    - Create controlled video animations\n    - Generate precise motion effects\n    - Produce customized video content\n    - Create fine-tuned animations\n    - Generate motion sequences",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.CogVideoX",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6363,21 +4709,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt",
         "video_size"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Fast SVD",
       "description": "Generate short video clips from your images using SVD v1.1 at Lightning Speed. Features high-quality motion synthesis with configurable parameters for rapid video generation.\n    video, generation, fast, motion, synthesis, img2vid, image-to-video\n\n    Use cases:\n    - Create quick video animations\n    - Generate rapid motion content\n    - Produce fast video transitions\n    - Create instant visual effects\n    - Generate quick previews",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.FastSVD",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6442,21 +4784,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "motion_bucket_id",
         "fps"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Haiper Image To Video",
       "description": "Transform images into hyper-realistic videos with Haiper 2.0. Experience industry-leading resolution, fluid motion, and rapid generation for stunning AI videos.\n    video, generation, hyper-realistic, motion, animation, image-to-video, img2vid\n\n    Use cases:\n    - Create cinematic animations\n    - Generate dynamic video content\n    - Transform static images into motion\n    - Produce high-resolution videos\n    - Create visual effects",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.HaiperImageToVideo",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6517,21 +4855,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt",
         "duration"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Kling Video",
       "description": "Generate video clips from your images using Kling 1.6. Supports multiple durations and aspect ratios.\n    video, generation, animation, duration, aspect-ratio, img2vid, image-to-video\n\n    Use cases:\n    - Create custom video content\n    - Generate video animations\n    - Transform static images\n    - Produce motion graphics\n    - Create visual presentations",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.KlingVideo",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6593,21 +4927,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt",
         "duration"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Kling Video Pro",
       "description": "Generate video clips from your images using Kling 1.6 Pro. The professional version offers enhanced quality and performance compared to the standard version.\n    video, generation, professional, quality, performance, img2vid, image-to-video\n\n    Use cases:\n    - Create professional video content\n    - Generate high-quality animations\n    - Produce commercial video assets\n    - Create advanced motion graphics\n    - Generate premium visual content",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.KlingVideoPro",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6669,21 +4999,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt",
         "duration"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "LTXVideo",
       "description": "Generate videos from images using LTX Video. Best results with 768x512 images and detailed, chronological descriptions of actions and scenes.\n    video, generation, chronological, scenes, actions, img2vid, image-to-video\n\n    Use cases:\n    - Create scene-based animations\n    - Generate sequential video content\n    - Produce narrative videos\n    - Create storyboard animations\n    - Generate action sequences",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.LTXVideo",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6748,20 +5074,16 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Luma Dream Machine",
       "description": "Generate video clips from your images using Luma Dream Machine v1.5. Supports various aspect ratios and optional end-frame blending.\n    video, generation, animation, blending, aspect-ratio, img2vid, image-to-video\n\n    Use cases:\n    - Create seamless video loops\n    - Generate video transitions\n    - Transform images into animations\n    - Create motion graphics\n    - Produce video content",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.LumaDreamMachine",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6834,21 +5156,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt",
         "aspect_ratio"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Mini Max Video",
       "description": "Generate video clips from your images using MiniMax Video model. Transform static art into dynamic masterpieces with enhanced smoothness and vivid motion.\n    video, generation, art, motion, smoothness, img2vid, image-to-video\n\n    Use cases:\n    - Transform artwork into videos\n    - Create smooth animations\n    - Generate artistic motion content\n    - Produce dynamic visualizations\n    - Create video art pieces",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.MiniMaxVideo",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -6886,20 +5204,16 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "prompt"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Muse Talk",
       "description": "Real-time high quality audio-driven lip-syncing model. Animate a face video with custom audio for natural-looking speech animation.\n    video, lip-sync, animation, speech, real-time, wav2vid, audio-to-video\n\n    Use cases:\n    - Create lip-synced videos\n    - Generate speech animations\n    - Produce dubbed content\n    - Create animated presentations\n    - Generate voice-over videos",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.MuseTalk",
-      "layout": "default",
       "properties": [
         {
           "name": "video",
@@ -6928,20 +5242,91 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "video",
         "audio"
+      ]
+    },
+    {
+      "title": "Pix Verse",
+      "description": "Generate dynamic videos from images with PixVerse v4.5. Create high-quality motion\n    with detailed prompt control and advanced diffusion parameters.\n    video, generation, pixverse, motion, diffusion, img2vid, image-to-video\n\n    Use cases:\n    - Animate illustrations and photos\n    - Produce engaging social media clips\n    - Generate short cinematic shots\n    - Create motion for product showcases\n    - Experiment with creative video effects",
+      "namespace": "fal.image_to_video",
+      "node_type": "fal.image_to_video.PixVerse",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The image to transform into a video"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "A description of the desired video motion and style"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "low quality, worst quality, distorted, blurred",
+          "title": "Negative Prompt",
+          "description": "What to avoid in the generated video"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 50,
+          "title": "Num Inference Steps",
+          "description": "Number of inference steps (higher = better quality but slower)"
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 7.5,
+          "title": "Guidance Scale",
+          "description": "How closely to follow the prompt (higher = more faithful)"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same video every time"
+        }
       ],
-      "is_dynamic": false
+      "outputs": [
+        {
+          "type": {
+            "type": "video"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "prompt",
+        "num_inference_steps"
+      ]
     },
     {
       "title": "Sad Talker",
       "description": "Generate talking face animations from a single image and audio file. Features configurable face model resolution and expression controls.\n    video, animation, face, talking, expression, img2vid, image-to-video, audio-to-video, wav2vid\n\n    Use cases:\n    - Create talking head videos\n    - Generate lip-sync animations\n    - Produce character animations\n    - Create video presentations\n    - Generate facial expressions",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.SadTalker",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -7019,21 +5404,17 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "audio",
         "face_model_resolution"
-      ],
-      "is_dynamic": false
+      ]
     },
     {
       "title": "Stable Video",
       "description": "Generate short video clips from your images using Stable Video Diffusion v1.1. Features high-quality motion synthesis with configurable parameters.\n    video, generation, diffusion, motion, synthesis, img2vid, image-to-video\n\n    Use cases:\n    - Create stable video animations\n    - Generate motion content\n    - Transform images into videos\n    - Produce smooth transitions\n    - Create visual effects",
       "namespace": "fal.image_to_video",
       "node_type": "fal.image_to_video.StableVideo",
-      "layout": "default",
       "properties": [
         {
           "name": "image",
@@ -7089,14 +5470,1475 @@
           "name": "output"
         }
       ],
-      "the_model_info": {},
-      "recommended_models": [],
       "basic_fields": [
         "image",
         "motion_bucket_id",
         "fps"
+      ]
+    },
+    {
+      "title": "Bria Background Remove",
+      "description": "Bria RMBG 2.0 enables seamless removal of backgrounds from images, ideal for professional editing tasks.\n    Trained exclusively on licensed data for safe and risk-free commercial use.",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaBackgroundRemove",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "Input image to remove background from"
+        }
       ],
-      "is_dynamic": false
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image"
+      ]
+    },
+    {
+      "title": "Bria Background Replace",
+      "description": "Bria Background Replace allows for efficient swapping of backgrounds in images via text prompts or reference image, delivering realistic and polished results. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, background, replacement, swap\n\n    Use cases:\n    - Replace image backgrounds seamlessly\n    - Create professional photo compositions\n    - Generate custom scene settings\n    - Produce commercial-ready images\n    - Create consistent visual environments",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaBackgroundReplace",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "Input image to replace background"
+        },
+        {
+          "name": "ref_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Ref Image",
+          "description": "Reference image for the new background"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "Prompt to generate new background"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "Negative prompt for background generation"
+        },
+        {
+          "name": "refine_prompt",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Refine Prompt",
+          "description": "Whether to refine the prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "prompt"
+      ]
+    },
+    {
+      "title": "Bria Eraser",
+      "description": "Bria Eraser enables precise removal of unwanted objects from images while maintaining high-quality outputs. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, removal, cleanup\n\n    Use cases:\n    - Remove unwanted objects from images\n    - Clean up image imperfections\n    - Prepare images for commercial use\n    - Remove distracting elements\n    - Create clean, professional images",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaEraser",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "Input image to erase from"
+        },
+        {
+          "name": "mask",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Mask",
+          "description": "The mask for areas to be cleaned"
+        },
+        {
+          "name": "mask_type",
+          "type": {
+            "type": "str"
+          },
+          "default": "manual",
+          "title": "Mask Type",
+          "description": "Type of mask - 'manual' for user-created or 'automatic' for algorithm-generated"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "mask"
+      ]
+    },
+    {
+      "title": "Bria Expand",
+      "description": "Bria Expand expands images beyond their borders in high quality. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, expansion, outpainting\n\n    Use cases:\n    - Extend image boundaries seamlessly\n    - Create wider or taller compositions\n    - Expand images for different aspect ratios\n    - Generate additional scene content",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaExpand",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to expand"
+        },
+        {
+          "name": "canvas_width",
+          "type": {
+            "type": "int"
+          },
+          "default": 1200,
+          "title": "Canvas Width",
+          "description": "The desired width of the final image, after the expansion"
+        },
+        {
+          "name": "canvas_height",
+          "type": {
+            "type": "int"
+          },
+          "default": 674,
+          "title": "Canvas Height",
+          "description": "The desired height of the final image, after the expansion"
+        },
+        {
+          "name": "original_image_width",
+          "type": {
+            "type": "int"
+          },
+          "default": 610,
+          "title": "Original Image Width",
+          "description": "The desired width of the original image, inside the full canvas"
+        },
+        {
+          "name": "original_image_height",
+          "type": {
+            "type": "int"
+          },
+          "default": 855,
+          "title": "Original Image Height",
+          "description": "The desired height of the original image, inside the full canvas"
+        },
+        {
+          "name": "original_image_x",
+          "type": {
+            "type": "int"
+          },
+          "default": 301,
+          "title": "Original Image X",
+          "description": "The desired x-coordinate of the original image, inside the full canvas"
+        },
+        {
+          "name": "original_image_y",
+          "type": {
+            "type": "int"
+          },
+          "default": -66,
+          "title": "Original Image Y",
+          "description": "The desired y-coordinate of the original image, inside the full canvas"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "Text on which you wish to base the image expansion"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt to use when generating images"
+        },
+        {
+          "name": "num_images",
+          "type": {
+            "type": "int"
+          },
+          "default": 1,
+          "title": "Num Images",
+          "description": "Number of images to generate"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "canvas_width",
+        "canvas_height",
+        "prompt"
+      ]
+    },
+    {
+      "title": "Bria Gen Fill",
+      "description": "Bria GenFill enables high-quality object addition or visual transformation. Trained exclusively on licensed data for safe and risk-free commercial use.\n    image, generation, filling, transformation\n\n    Use cases:\n    - Add new objects to existing images\n    - Transform specific image areas\n    - Generate contextual content\n    - Create seamless visual additions\n    - Produce professional image modifications",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaGenFill",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "Input image to erase from"
+        },
+        {
+          "name": "mask",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Mask",
+          "description": "The mask for areas to be cleaned"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate images"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt to use when generating images"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "mask",
+        "prompt"
+      ]
+    },
+    {
+      "title": "Bria Product Shot",
+      "description": "Place any product in any scenery with just a prompt or reference image while maintaining high integrity of the product. Trained exclusively on licensed data for safe and risk-free commercial use and optimized for eCommerce.\n    image, product, placement, ecommerce\n\n    Use cases:\n    - Create professional product photography\n    - Generate contextual product shots\n    - Place products in custom environments\n    - Create eCommerce product listings\n    - Generate marketing visuals",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.BriaProductShot",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The product image to be placed"
+        },
+        {
+          "name": "scene_description",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Scene Description",
+          "description": "Text description of the new scene/background"
+        },
+        {
+          "name": "ref_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Ref Image",
+          "description": "Reference image for the new scene/background"
+        },
+        {
+          "name": "optimize_description",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Optimize Description",
+          "description": "Whether to optimize the scene description"
+        },
+        {
+          "name": "placement_type",
+          "type": {
+            "type": "str"
+          },
+          "default": "manual_placement",
+          "title": "Placement Type",
+          "description": "How to position the product (original, automatic, manual_placement, manual_padding)"
+        },
+        {
+          "name": "manual_placement_selection",
+          "type": {
+            "type": "str"
+          },
+          "default": "bottom_center",
+          "title": "Manual Placement Selection",
+          "description": "Specific placement position when using manual_placement"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "scene_description"
+      ]
+    },
+    {
+      "title": "Clarity Upscaler",
+      "description": "Upscale images to improve resolution and sharpness.\n\n    clarity, upscale, enhancement\n\n    Use cases:\n    - Increase image resolution for printing\n    - Improve clarity of low-quality images\n    - Enhance textures and graphics",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.ClarityUpscaler",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "Input image to upscale"
+        },
+        {
+          "name": "scale",
+          "type": {
+            "type": "int"
+          },
+          "default": 2,
+          "title": "Scale",
+          "description": "Upscaling factor",
+          "min": 1.0,
+          "max": 4.0
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "scale"
+      ]
+    },
+    {
+      "title": "Flux Dev Redux",
+      "description": "FLUX.1 [dev] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications.\n    image, transformation, style-transfer, development, flux\n\n    Use cases:\n    - Transform images with advanced controls\n    - Create customized image variations\n    - Apply precise style modifications",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxDevRedux",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to transform"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "enable_safety_checker",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Enable Safety Checker",
+          "description": "If true, the safety checker will be enabled"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "image_size",
+        "guidance_scale"
+      ]
+    },
+    {
+      "title": "Flux Lora Canny",
+      "description": "FLUX LoRA Canny enables precise control over composition and style through edge detection and LoRA-based guidance mechanisms.\n    image, edge, lora, style-transfer, control\n\n    Use cases:\n    - Generate stylized images with structural control\n    - Create edge-guided artistic transformations\n    - Apply custom styles while maintaining composition\n    - Produce consistent style variations",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxLoraCanny",
+      "properties": [
+        {
+          "name": "control_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Control Image",
+          "description": "The control image to generate the Canny edge map from"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate an image from"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "lora_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 0.6,
+          "title": "Lora Scale",
+          "description": "The strength of the LoRA adaptation"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "control_image",
+        "prompt",
+        "image_size"
+      ]
+    },
+    {
+      "title": "Flux Lora Depth",
+      "description": "FLUX LoRA Depth enables precise control over composition and structure through depth map detection and LoRA-based guidance mechanisms.\n    image, depth, lora, structure, control\n\n    Use cases:\n    - Generate depth-aware stylized images\n    - Create 3D-conscious artistic transformations\n    - Maintain spatial relationships with custom styles\n    - Produce depth-consistent variations\n    - Generate images with controlled perspective",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxLoraDepth",
+      "properties": [
+        {
+          "name": "control_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Control Image",
+          "description": "The control image to generate the depth map from"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate an image from"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "lora_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 0.6,
+          "title": "Lora Scale",
+          "description": "The strength of the LoRA adaptation"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "control_image",
+        "prompt",
+        "image_size"
+      ]
+    },
+    {
+      "title": "Flux Pro Canny",
+      "description": "FLUX.1 [pro] Canny enables precise control over composition, style, and structure through advanced edge detection and guidance mechanisms.\n    image, edge, composition, style, control\n\n    Use cases:\n    - Generate images with precise structural control\n    - Create artwork based on edge maps\n    - Transform sketches into detailed images\n    - Maintain specific compositional elements\n    - Generate variations with consistent structure",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxProCanny",
+      "properties": [
+        {
+          "name": "control_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Control Image",
+          "description": "The control image to generate the Canny edge map from"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate an image from"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "safety_tolerance",
+          "type": {
+            "type": "str"
+          },
+          "default": "2",
+          "title": "Safety Tolerance",
+          "description": "Safety tolerance level (1-6, 1 being most strict)"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "control_image",
+        "prompt",
+        "image_size"
+      ]
+    },
+    {
+      "title": "Flux Pro Depth",
+      "description": "FLUX.1 [pro] Depth enables precise control over composition and structure through depth map detection and guidance mechanisms.\n    image, depth-map, composition, structure, control\n\n    Use cases:\n    - Generate images with controlled depth perception\n    - Create 3D-aware image transformations\n    - Maintain spatial relationships in generated images\n    - Produce images with accurate perspective\n    - Generate variations with consistent depth structure",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxProDepth",
+      "properties": [
+        {
+          "name": "control_image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Control Image",
+          "description": "The control image to generate the depth map from"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate an image from"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "safety_tolerance",
+          "type": {
+            "type": "str"
+          },
+          "default": "2",
+          "title": "Safety Tolerance",
+          "description": "Safety tolerance level (1-6, 1 being most strict)"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "control_image",
+        "prompt",
+        "image_size"
+      ]
+    },
+    {
+      "title": "Flux Pro Fill",
+      "description": "FLUX.1 [pro] Fill is a high-performance endpoint that enables rapid transformation of existing images with inpainting/outpainting capabilities.\n    image, inpainting, outpainting, transformation, professional\n\n    Use cases:\n    - Fill in missing or masked parts of images\n    - Extend images beyond their original boundaries\n    - Remove and replace unwanted elements\n    - Create seamless image completions\n    - Generate context-aware image content",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxProFill",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to transform"
+        },
+        {
+          "name": "mask",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Mask",
+          "description": "The mask for inpainting"
+        },
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to fill the masked part of the image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "safety_tolerance",
+          "type": {
+            "type": "str"
+          },
+          "default": "2",
+          "title": "Safety Tolerance",
+          "description": "Safety tolerance level (1-6, 1 being most strict)"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "mask",
+        "prompt"
+      ]
+    },
+    {
+      "title": "Flux Pro Redux",
+      "description": "FLUX.1 [pro] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications.\n    image, transformation, style-transfer, flux\n\n    Use cases:\n    - Create professional image transformations\n    - Generate style transfers",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxProRedux",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to transform"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "safety_tolerance",
+          "type": {
+            "type": "str"
+          },
+          "default": "2",
+          "title": "Safety Tolerance",
+          "description": "Safety tolerance level (1-6, 1 being most strict)"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "image_size",
+        "guidance_scale"
+      ]
+    },
+    {
+      "title": "Flux Pro Ultra Redux",
+      "description": "FLUX1.1 [pro] ultra Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications with the core FLUX capabilities.\n    image, transformation, style-transfer, ultra, professional\n\n    Use cases:\n    - Apply precise image modifications\n    - Process images with maximum control",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxProUltraRedux",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to transform"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 28,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "guidance_scale",
+          "type": {
+            "type": "float"
+          },
+          "default": 3.5,
+          "title": "Guidance Scale",
+          "description": "How closely the model should stick to your prompt"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "safety_tolerance",
+          "type": {
+            "type": "str"
+          },
+          "default": "2",
+          "title": "Safety Tolerance",
+          "description": "Safety tolerance level (1-6, 1 being most strict)"
+        },
+        {
+          "name": "image_prompt_strength",
+          "type": {
+            "type": "float"
+          },
+          "default": 0.1,
+          "title": "Image Prompt Strength",
+          "description": "The strength of the image prompt, between 0 and 1"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "image_size",
+        "guidance_scale"
+      ]
+    },
+    {
+      "title": "Flux Schnell Redux",
+      "description": "FLUX.1 [schnell] Redux is a high-performance endpoint that enables rapid transformation of existing images, delivering high-quality style transfers and image modifications with the core FLUX capabilities.\n    image, transformation, style-transfer, fast, flux\n\n    Use cases:\n    - Transform images with style transfers\n    - Apply artistic modifications to photos\n    - Create image variations",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.FluxSchnellRedux",
+      "properties": [
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The input image to transform"
+        },
+        {
+          "name": "image_size",
+          "type": {
+            "type": "enum",
+            "values": [
+              "square_hd",
+              "square",
+              "portrait_4_3",
+              "portrait_16_9",
+              "landscape_4_3",
+              "landscape_16_9"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_image.ImageSizePreset"
+          },
+          "default": "landscape_4_3",
+          "title": "Image Size",
+          "description": "The size of the generated image"
+        },
+        {
+          "name": "num_inference_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 4,
+          "title": "Num Inference Steps",
+          "description": "The number of inference steps to perform",
+          "min": 1.0
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        },
+        {
+          "name": "enable_safety_checker",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Enable Safety Checker",
+          "description": "If true, the safety checker will be enabled"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "image",
+        "image_size",
+        "num_inference_steps"
+      ]
+    },
+    {
+      "title": "Ideogram V 2 Edit",
+      "description": "Transform existing images with Ideogram V2's editing capabilities. Modify, adjust, and refine images while maintaining high fidelity and realistic outputs with precise prompt control.\n    image, editing, transformation, fidelity, control\n\n    Use cases:\n    - Edit specific parts of images with precision\n    - Create targeted image modifications\n    - Refine and enhance image details\n    - Generate contextual image edits",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.IdeogramV2Edit",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to fill the masked part of the image"
+        },
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The image to edit"
+        },
+        {
+          "name": "mask",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Mask",
+          "description": "The mask for editing"
+        },
+        {
+          "name": "style",
+          "type": {
+            "type": "str"
+          },
+          "default": "auto",
+          "title": "Style",
+          "description": "Style of generated image (auto, general, realistic, design, render_3D, anime)"
+        },
+        {
+          "name": "expand_prompt",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Expand Prompt",
+          "description": "Whether to expand the prompt with MagicPrompt functionality"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "image",
+        "mask"
+      ]
+    },
+    {
+      "title": "Ideogram V 2 Remix",
+      "description": "Reimagine existing images with Ideogram V2's remix feature. Create variations and adaptations while preserving core elements and adding new creative directions through prompt guidance.\n    image, remix, variation, creativity, adaptation\n\n    Use cases:\n    - Create artistic variations of images\n    - Generate style-transferred versions\n    - Produce creative image adaptations\n    - Transform images while preserving key elements\n    - Generate alternative interpretations",
+      "namespace": "fal.image_to_image",
+      "node_type": "fal.image_to_image.IdeogramV2Remix",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to remix the image with"
+        },
+        {
+          "name": "image",
+          "type": {
+            "type": "image"
+          },
+          "default": {},
+          "title": "Image",
+          "description": "The image to remix"
+        },
+        {
+          "name": "aspect_ratio",
+          "type": {
+            "type": "str"
+          },
+          "default": "1:1",
+          "title": "Aspect Ratio",
+          "description": "The aspect ratio of the generated image"
+        },
+        {
+          "name": "strength",
+          "type": {
+            "type": "float"
+          },
+          "default": 0.8,
+          "title": "Strength",
+          "description": "Strength of the input image in the remix"
+        },
+        {
+          "name": "expand_prompt",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Expand Prompt",
+          "description": "Whether to expand the prompt with MagicPrompt functionality"
+        },
+        {
+          "name": "style",
+          "type": {
+            "type": "str"
+          },
+          "default": "auto",
+          "title": "Style",
+          "description": "Style of generated image (auto, general, realistic, design, render_3D, anime)"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same image every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "image"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "image",
+        "strength"
+      ]
+    },
+    {
+      "title": "Any LLM",
+      "description": "Use any large language model from a selected catalogue (powered by OpenRouter).\n    Supports various models including Claude 3, Gemini, Llama, and GPT-4.\n    llm, text, generation, ai, language\n\n    Use cases:\n    - Generate natural language responses\n    - Create conversational AI interactions\n    - Process and analyze text content\n    - Generate creative writing\n    - Assist with problem-solving tasks",
+      "namespace": "fal.llm",
+      "node_type": "fal.llm.AnyLLM",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to send to the language model"
+        },
+        {
+          "name": "system_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "System Prompt",
+          "description": "Optional system prompt to provide context or instructions"
+        },
+        {
+          "name": "model",
+          "type": {
+            "type": "enum",
+            "values": [
+              "anthropic/claude-3.5-sonnet",
+              "anthropic/claude-3-5-haiku",
+              "anthropic/claude-3-haiku",
+              "google/gemini-pro-1.5",
+              "google/gemini-flash-1.5",
+              "google/gemini-flash-1.5-8b",
+              "meta-llama/llama-3.2-1b-instruct",
+              "meta-llama/llama-3.2-3b-instruct",
+              "meta-llama/llama-3.1-8b-instruct",
+              "meta-llama/llama-3.1-70b-instruct",
+              "openai/gpt-4o-mini",
+              "openai/gpt-4o"
+            ],
+            "type_name": "nodetool.nodes.fal.llm.ModelEnum"
+          },
+          "default": "google/gemini-flash-1.5",
+          "title": "Model",
+          "description": "The language model to use for the completion"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "str"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "model",
+        "system_prompt"
+      ]
     }
   ]
 }

--- a/src/nodetool/utils.py
+++ b/src/nodetool/utils.py
@@ -1,0 +1,3 @@
+def add(a: int, b: int) -> int:
+    """Return the sum of *a* and *b*."""
+    return a + b

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from nodetool.utils import add
+
+def test_add():
+    assert add(1, 2) == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,5 +5,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from nodetool.utils import add
 
+
 def test_add():
     assert add(1, 2) == 3


### PR DESCRIPTION
## Summary
- implement `PixVerse` node for converting images to video

## Testing
- `ruff check .` *(fails: unused imports in generated DSL)*
- `black --check src/nodetool/nodes/fal/image_to_video.py`
- `pytest -q`
