### PR TITLE
Add text2image example workflow

### DIFF
--- a/.github/workflows/text2image.yml
+++ b/.github/workflows/text2image.yml
@@ -1,0 +1,21 @@
+name: Text2Image Example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-text2image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run example node
+        env:
+          FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
+        run: python examples/run_text2image.py

--- a/examples/run_text2image.py
+++ b/examples/run_text2image.py
@@ -1,0 +1,22 @@
+import asyncio
+import os
+
+from nodetool.nodes.fal.text_to_image import IdeogramV2
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+async def main() -> None:
+    # Create node with a simple prompt
+    node = IdeogramV2(prompt="a colorful parrot")
+
+    # FAL_API_KEY must be provided via environment variables
+    context = ProcessingContext(
+        environment={"FAL_API_KEY": os.getenv("FAL_API_KEY", "")}
+    )
+
+    image = await node.process(context)
+    print("Generated image URL:", image.uri)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add sample script to run a Text to Image node
- add a GitHub Actions workflow to install dependencies and run the example

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
