### PR TITLE
Add artifact upload to text2image workflow

### DIFF
--- a/.github/workflows/text2image.yml
+++ b/.github/workflows/text2image.yml
@@ -19,3 +19,8 @@ jobs:
         env:
           FAL_API_KEY: ${{ secrets.FAL_API_KEY }}
         run: python examples/run_text2image.py
+      - name: Upload generated image
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-image
+          path: generated_image.png

--- a/examples/run_text2image.py
+++ b/examples/run_text2image.py
@@ -17,6 +17,15 @@ async def main() -> None:
     image = await node.process(context)
     print("Generated image URL:", image.uri)
 
+    # Download the generated image so it can be uploaded as a workflow artifact
+    import urllib.request
+
+    with urllib.request.urlopen(image.uri) as response, open(
+        "generated_image.png", "wb"
+    ) as out_file:
+        out_file.write(response.read())
+    print("Image saved to generated_image.png")
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- save image locally in `run_text2image.py`
- upload saved image as artifact in workflow

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
