### PR TITLE
Add Veo3 text-to-video node

### DIFF
--- a/src/nodetool/dsl/fal/text_to_video.py
+++ b/src/nodetool/dsl/fal/text_to_video.py
@@ -1,0 +1,57 @@
+from pydantic import BaseModel, Field
+import typing
+from typing import Any
+import nodetool.metadata.types
+import nodetool.metadata.types as types
+from nodetool.dsl.graph import GraphNode
+
+import nodetool.nodes.fal.text_to_video
+import nodetool.nodes.fal.text_to_video
+
+
+class Veo3(GraphNode):
+    """
+    Generate high-quality videos from text prompts with Google's Veo 3 model.
+    video, generation, text-to-video, prompt, audio
+
+    Use cases:
+    - Produce short cinematic clips from descriptions
+    - Create social media videos
+    - Generate visual storyboards
+    - Experiment with video concepts
+    - Produce marketing content
+    """
+
+    Veo3AspectRatio: typing.ClassVar[type] = (
+        nodetool.nodes.fal.text_to_video.Veo3AspectRatio
+    )
+    Veo3Duration: typing.ClassVar[type] = nodetool.nodes.fal.text_to_video.Veo3Duration
+    prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="",
+        description="The text prompt describing the video you want to generate",
+    )
+    aspect_ratio: nodetool.nodes.fal.text_to_video.Veo3AspectRatio = Field(
+        default=nodetool.nodes.fal.text_to_video.Veo3AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated video. If it is not set to 16:9, the video will be outpainted with Luma Ray 2 Reframe functionality.",
+    )
+    duration: nodetool.nodes.fal.text_to_video.Veo3Duration = Field(
+        default=nodetool.nodes.fal.text_to_video.Veo3Duration.EIGHT_SECONDS,
+        description="The duration of the generated video in seconds",
+    )
+    generate_audio: bool | GraphNode | tuple[GraphNode, str] = Field(
+        default=True,
+        description="Whether to generate audio for the video. If false, %33 less credits will be used.",
+    )
+    seed: int | GraphNode | tuple[GraphNode, str] = Field(
+        default=-1, description="A seed to use for the video generation"
+    )
+    negative_prompt: str | GraphNode | tuple[GraphNode, str] = Field(
+        default="", description="A negative prompt to guide the video generation"
+    )
+    enhance_prompt: bool | GraphNode | tuple[GraphNode, str] = Field(
+        default=True, description="Whether to enhance the video generation"
+    )
+
+    @classmethod
+    def get_node_type(cls):
+        return "fal.text_to_video.Veo3"

--- a/src/nodetool/nodes/fal/__init__.py
+++ b/src/nodetool/nodes/fal/__init__.py
@@ -4,3 +4,4 @@ import nodetool.nodes.fal.text_to_audio  # noqa: F401
 import nodetool.nodes.fal.speech_to_text  # noqa: F401
 import nodetool.nodes.fal.image_to_image  # noqa: F401
 import nodetool.nodes.fal.image_to_video  # noqa: F401
+import nodetool.nodes.fal.text_to_video  # noqa: F401

--- a/src/nodetool/nodes/fal/text_to_video.py
+++ b/src/nodetool/nodes/fal/text_to_video.py
@@ -1,0 +1,80 @@
+from enum import Enum
+
+from pydantic import Field
+
+from nodetool.metadata.types import VideoRef
+from nodetool.nodes.fal.fal_node import FALNode
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class Veo3AspectRatio(Enum):
+    RATIO_16_9 = "16:9"
+    RATIO_9_16 = "9:16"
+    RATIO_1_1 = "1:1"
+
+
+class Veo3Duration(Enum):
+    EIGHT_SECONDS = "8s"
+
+
+class Veo3(FALNode):
+    """
+    Generate high-quality videos from text prompts with Google's Veo 3 model.
+    video, generation, text-to-video, prompt, audio
+
+    Use cases:
+    - Produce short cinematic clips from descriptions
+    - Create social media videos
+    - Generate visual storyboards
+    - Experiment with video concepts
+    - Produce marketing content
+    """
+
+    prompt: str = Field(
+        default="",
+        description="The text prompt describing the video you want to generate",
+    )
+    aspect_ratio: Veo3AspectRatio = Field(
+        default=Veo3AspectRatio.RATIO_16_9,
+        description="The aspect ratio of the generated video. If it is not set to 16:9, the video will be outpainted with Luma Ray 2 Reframe functionality.",
+    )
+    duration: Veo3Duration = Field(
+        default=Veo3Duration.EIGHT_SECONDS,
+        description="The duration of the generated video in seconds",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Whether to generate audio for the video. If false, %33 less credits will be used.",
+    )
+    seed: int = Field(default=-1, description="A seed to use for the video generation")
+    negative_prompt: str = Field(
+        default="", description="A negative prompt to guide the video generation"
+    )
+    enhance_prompt: bool = Field(
+        default=True, description="Whether to enhance the video generation"
+    )
+
+    async def process(self, context: ProcessingContext) -> VideoRef:
+        arguments = {
+            "prompt": self.prompt,
+            "aspect_ratio": self.aspect_ratio.value,
+            "duration": self.duration.value,
+            "generate_audio": self.generate_audio,
+            "enhance_prompt": self.enhance_prompt,
+        }
+        if self.seed != -1:
+            arguments["seed"] = self.seed
+        if self.negative_prompt:
+            arguments["negative_prompt"] = self.negative_prompt
+
+        res = await self.submit_request(
+            context=context,
+            application="fal-ai/veo3",
+            arguments=arguments,
+        )
+        assert "video" in res
+        return VideoRef(uri=res["video"]["url"])
+
+    @classmethod
+    def get_basic_fields(cls):
+        return ["prompt", "aspect_ratio", "duration"]

--- a/src/nodetool/package_metadata/nodetool-fal.json
+++ b/src/nodetool/package_metadata/nodetool-fal.json
@@ -8,229 +8,6 @@
   "repo_id": "nodetool-ai/nodetool-fal",
   "nodes": [
     {
-      "title": "F5 TTS",
-      "description": "F5 TTS (Text-to-Speech) model for generating natural-sounding speech from text with voice cloning capabilities.\n    audio, tts, voice-cloning, speech, synthesis, text-to-speech, tts, text-to-audio\n\n    Use cases:\n    - Generate natural speech from text\n    - Clone and replicate voices\n    - Create custom voiceovers\n    - Produce multilingual speech content\n    - Generate personalized audio content",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.F5TTS",
-      "properties": [
-        {
-          "name": "gen_text",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Gen Text",
-          "description": "The text to be converted to speech"
-        },
-        {
-          "name": "ref_audio_url",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Ref Audio Url",
-          "description": "URL of the reference audio file to clone the voice from"
-        },
-        {
-          "name": "ref_text",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Ref Text",
-          "description": "Optional reference text. If not provided, ASR will be used"
-        },
-        {
-          "name": "model_type",
-          "type": {
-            "type": "str"
-          },
-          "default": "F5-TTS",
-          "title": "Model Type",
-          "description": "Model type to use (F5-TTS or E2-TTS)"
-        },
-        {
-          "name": "remove_silence",
-          "type": {
-            "type": "bool"
-          },
-          "default": true,
-          "title": "Remove Silence",
-          "description": "Whether to remove silence from the generated audio"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "basic_fields": [
-        "gen_text",
-        "ref_audio_url",
-        "model_type"
-      ]
-    },
-    {
-      "title": "MMAudio V2",
-      "description": "MMAudio V2 generates synchronized audio given text inputs. It can generate sounds described by a prompt.\n    audio, generation, synthesis, text-to-audio, synchronization\n\n    Use cases:\n    - Generate synchronized audio from text descriptions\n    - Create custom sound effects\n    - Produce ambient soundscapes\n    - Generate audio for multimedia content\n    - Create sound design elements",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.MMAudioV2",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate the audio for"
-        },
-        {
-          "name": "negative_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Negative Prompt",
-          "description": "The negative prompt to avoid certain elements in the generated audio"
-        },
-        {
-          "name": "num_steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 25,
-          "title": "Num Steps",
-          "description": "The number of steps to generate the audio for",
-          "min": 1.0
-        },
-        {
-          "name": "duration",
-          "type": {
-            "type": "float"
-          },
-          "default": 8.0,
-          "title": "Duration",
-          "description": "The duration of the audio to generate in seconds",
-          "min": 1.0
-        },
-        {
-          "name": "cfg_strength",
-          "type": {
-            "type": "float"
-          },
-          "default": 4.5,
-          "title": "Cfg Strength",
-          "description": "The strength of Classifier Free Guidance"
-        },
-        {
-          "name": "mask_away_clip",
-          "type": {
-            "type": "bool"
-          },
-          "default": false,
-          "title": "Mask Away Clip",
-          "description": "Whether to mask away the clip"
-        },
-        {
-          "name": "seed",
-          "type": {
-            "type": "int"
-          },
-          "default": -1,
-          "title": "Seed",
-          "description": "The same seed will output the same audio every time"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "basic_fields": [
-        "prompt",
-        "duration",
-        "num_steps"
-      ]
-    },
-    {
-      "title": "Stable Audio",
-      "description": "Stable Audio generates audio from text prompts. Open source text-to-audio model from fal.ai.\n    audio, generation, synthesis, text-to-audio, open-source\n\n    Use cases:\n    - Generate custom audio content from text\n    - Create background music and sounds\n    - Produce audio assets for projects\n    - Generate sound effects\n    - Create experimental audio content",
-      "namespace": "fal.text_to_audio",
-      "node_type": "fal.text_to_audio.StableAudio",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to generate the audio from"
-        },
-        {
-          "name": "seconds_start",
-          "type": {
-            "type": "int"
-          },
-          "default": 0,
-          "title": "Seconds Start",
-          "description": "The start point of the audio clip to generate"
-        },
-        {
-          "name": "seconds_total",
-          "type": {
-            "type": "int"
-          },
-          "default": 30,
-          "title": "Seconds Total",
-          "description": "The duration of the audio clip to generate in seconds"
-        },
-        {
-          "name": "steps",
-          "type": {
-            "type": "int"
-          },
-          "default": 100,
-          "title": "Steps",
-          "description": "The number of steps to denoise the audio for"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "audio"
-          },
-          "name": "output"
-        }
-      ],
-      "basic_fields": [
-        "prompt",
-        "seconds_total",
-        "steps"
-      ]
-    },
-    {
-      "title": "FAL",
-      "description": "FAL Node for interacting with FAL AI services.\n    Provides methods to submit and handle API requests to FAL endpoints.",
-      "namespace": "fal.fal_node",
-      "node_type": "fal.fal_node.FAL",
-      "outputs": [
-        {
-          "type": {
-            "type": "any"
-          },
-          "name": "output"
-        }
-      ]
-    },
-    {
       "title": "Aura Flow V 03",
       "description": "AuraFlow v0.3 is an open-source flow-based text-to-image generation model that achieves state-of-the-art results on GenEval.\n    image, generation, flow-based, text-to-image, txt2img\n\n    Use cases:\n    - Generate high-quality images\n    - Create artistic visualizations",
       "namespace": "fal.text_to_image",
@@ -4309,6 +4086,309 @@
       ]
     },
     {
+      "title": "F5 TTS",
+      "description": "F5 TTS (Text-to-Speech) model for generating natural-sounding speech from text with voice cloning capabilities.\n    audio, tts, voice-cloning, speech, synthesis, text-to-speech, tts, text-to-audio\n\n    Use cases:\n    - Generate natural speech from text\n    - Clone and replicate voices\n    - Create custom voiceovers\n    - Produce multilingual speech content\n    - Generate personalized audio content",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.F5TTS",
+      "properties": [
+        {
+          "name": "gen_text",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Gen Text",
+          "description": "The text to be converted to speech"
+        },
+        {
+          "name": "ref_audio_url",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Ref Audio Url",
+          "description": "URL of the reference audio file to clone the voice from"
+        },
+        {
+          "name": "ref_text",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Ref Text",
+          "description": "Optional reference text. If not provided, ASR will be used"
+        },
+        {
+          "name": "model_type",
+          "type": {
+            "type": "str"
+          },
+          "default": "F5-TTS",
+          "title": "Model Type",
+          "description": "Model type to use (F5-TTS or E2-TTS)"
+        },
+        {
+          "name": "remove_silence",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Remove Silence",
+          "description": "Whether to remove silence from the generated audio"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "audio"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "gen_text",
+        "ref_audio_url",
+        "model_type"
+      ]
+    },
+    {
+      "title": "MMAudio V2",
+      "description": "MMAudio V2 generates synchronized audio given text inputs. It can generate sounds described by a prompt.\n    audio, generation, synthesis, text-to-audio, synchronization\n\n    Use cases:\n    - Generate synchronized audio from text descriptions\n    - Create custom sound effects\n    - Produce ambient soundscapes\n    - Generate audio for multimedia content\n    - Create sound design elements",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.MMAudioV2",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate the audio for"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt to avoid certain elements in the generated audio"
+        },
+        {
+          "name": "num_steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 25,
+          "title": "Num Steps",
+          "description": "The number of steps to generate the audio for",
+          "min": 1.0
+        },
+        {
+          "name": "duration",
+          "type": {
+            "type": "float"
+          },
+          "default": 8.0,
+          "title": "Duration",
+          "description": "The duration of the audio to generate in seconds",
+          "min": 1.0
+        },
+        {
+          "name": "cfg_strength",
+          "type": {
+            "type": "float"
+          },
+          "default": 4.5,
+          "title": "Cfg Strength",
+          "description": "The strength of Classifier Free Guidance"
+        },
+        {
+          "name": "mask_away_clip",
+          "type": {
+            "type": "bool"
+          },
+          "default": false,
+          "title": "Mask Away Clip",
+          "description": "Whether to mask away the clip"
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "The same seed will output the same audio every time"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "audio"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "duration",
+        "num_steps"
+      ]
+    },
+    {
+      "title": "Stable Audio",
+      "description": "Stable Audio generates audio from text prompts. Open source text-to-audio model from fal.ai.\n    audio, generation, synthesis, text-to-audio, open-source\n\n    Use cases:\n    - Generate custom audio content from text\n    - Create background music and sounds\n    - Produce audio assets for projects\n    - Generate sound effects\n    - Create experimental audio content",
+      "namespace": "fal.text_to_audio",
+      "node_type": "fal.text_to_audio.StableAudio",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to generate the audio from"
+        },
+        {
+          "name": "seconds_start",
+          "type": {
+            "type": "int"
+          },
+          "default": 0,
+          "title": "Seconds Start",
+          "description": "The start point of the audio clip to generate"
+        },
+        {
+          "name": "seconds_total",
+          "type": {
+            "type": "int"
+          },
+          "default": 30,
+          "title": "Seconds Total",
+          "description": "The duration of the audio clip to generate in seconds"
+        },
+        {
+          "name": "steps",
+          "type": {
+            "type": "int"
+          },
+          "default": 100,
+          "title": "Steps",
+          "description": "The number of steps to denoise the audio for"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "audio"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "seconds_total",
+        "steps"
+      ]
+    },
+    {
+      "title": "Veo 3",
+      "description": "Generate high-quality videos from text prompts with Google's Veo 3 model.\n    video, generation, text-to-video, prompt, audio\n\n    Use cases:\n    - Produce short cinematic clips from descriptions\n    - Create social media videos\n    - Generate visual storyboards\n    - Experiment with video concepts\n    - Produce marketing content",
+      "namespace": "fal.text_to_video",
+      "node_type": "fal.text_to_video.Veo3",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The text prompt describing the video you want to generate"
+        },
+        {
+          "name": "aspect_ratio",
+          "type": {
+            "type": "enum",
+            "values": [
+              "16:9",
+              "9:16",
+              "1:1"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_video.Veo3AspectRatio"
+          },
+          "default": "16:9",
+          "title": "Aspect Ratio",
+          "description": "The aspect ratio of the generated video. If it is not set to 16:9, the video will be outpainted with Luma Ray 2 Reframe functionality."
+        },
+        {
+          "name": "duration",
+          "type": {
+            "type": "enum",
+            "values": [
+              "8s"
+            ],
+            "type_name": "nodetool.nodes.fal.text_to_video.Veo3Duration"
+          },
+          "default": "8s",
+          "title": "Duration",
+          "description": "The duration of the generated video in seconds"
+        },
+        {
+          "name": "generate_audio",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Generate Audio",
+          "description": "Whether to generate audio for the video. If false, %33 less credits will be used."
+        },
+        {
+          "name": "seed",
+          "type": {
+            "type": "int"
+          },
+          "default": -1,
+          "title": "Seed",
+          "description": "A seed to use for the video generation"
+        },
+        {
+          "name": "negative_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "A negative prompt to guide the video generation"
+        },
+        {
+          "name": "enhance_prompt",
+          "type": {
+            "type": "bool"
+          },
+          "default": true,
+          "title": "Enhance Prompt",
+          "description": "Whether to enhance the video generation"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "video"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "aspect_ratio",
+        "duration"
+      ]
+    },
+    {
       "title": "Whisper",
       "description": "Whisper is a model for speech transcription and translation that can transcribe audio in multiple languages and optionally translate to English.\n    speech, audio, transcription, translation, transcribe, translate, multilingual, speech-to-text, audio-to-text\n\n    Use cases:\n    - Transcribe spoken content to text\n    - Translate speech to English\n    - Generate subtitles and captions\n    - Create text records of audio content\n    - Analyze multilingual audio content",
       "namespace": "fal.speech_to_text",
@@ -4547,6 +4627,83 @@
         "audio",
         "task",
         "diarize"
+      ]
+    },
+    {
+      "title": "FAL",
+      "description": "FAL Node for interacting with FAL AI services.\n    Provides methods to submit and handle API requests to FAL endpoints.",
+      "namespace": "fal.fal_node",
+      "node_type": "fal.fal_node.FAL",
+      "outputs": [
+        {
+          "type": {
+            "type": "any"
+          },
+          "name": "output"
+        }
+      ]
+    },
+    {
+      "title": "Any LLM",
+      "description": "Use any large language model from a selected catalogue (powered by OpenRouter).\n    Supports various models including Claude 3, Gemini, Llama, and GPT-4.\n    llm, text, generation, ai, language\n\n    Use cases:\n    - Generate natural language responses\n    - Create conversational AI interactions\n    - Process and analyze text content\n    - Generate creative writing\n    - Assist with problem-solving tasks",
+      "namespace": "fal.llm",
+      "node_type": "fal.llm.AnyLLM",
+      "properties": [
+        {
+          "name": "prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "Prompt",
+          "description": "The prompt to send to the language model"
+        },
+        {
+          "name": "system_prompt",
+          "type": {
+            "type": "str"
+          },
+          "default": "",
+          "title": "System Prompt",
+          "description": "Optional system prompt to provide context or instructions"
+        },
+        {
+          "name": "model",
+          "type": {
+            "type": "enum",
+            "values": [
+              "anthropic/claude-3.5-sonnet",
+              "anthropic/claude-3-5-haiku",
+              "anthropic/claude-3-haiku",
+              "google/gemini-pro-1.5",
+              "google/gemini-flash-1.5",
+              "google/gemini-flash-1.5-8b",
+              "meta-llama/llama-3.2-1b-instruct",
+              "meta-llama/llama-3.2-3b-instruct",
+              "meta-llama/llama-3.1-8b-instruct",
+              "meta-llama/llama-3.1-70b-instruct",
+              "openai/gpt-4o-mini",
+              "openai/gpt-4o"
+            ],
+            "type_name": "nodetool.nodes.fal.llm.ModelEnum"
+          },
+          "default": "google/gemini-flash-1.5",
+          "title": "Model",
+          "description": "The language model to use for the completion"
+        }
+      ],
+      "outputs": [
+        {
+          "type": {
+            "type": "str"
+          },
+          "name": "output"
+        }
+      ],
+      "basic_fields": [
+        "prompt",
+        "model",
+        "system_prompt"
       ]
     },
     {
@@ -6862,69 +7019,6 @@
         "prompt",
         "image",
         "strength"
-      ]
-    },
-    {
-      "title": "Any LLM",
-      "description": "Use any large language model from a selected catalogue (powered by OpenRouter).\n    Supports various models including Claude 3, Gemini, Llama, and GPT-4.\n    llm, text, generation, ai, language\n\n    Use cases:\n    - Generate natural language responses\n    - Create conversational AI interactions\n    - Process and analyze text content\n    - Generate creative writing\n    - Assist with problem-solving tasks",
-      "namespace": "fal.llm",
-      "node_type": "fal.llm.AnyLLM",
-      "properties": [
-        {
-          "name": "prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "Prompt",
-          "description": "The prompt to send to the language model"
-        },
-        {
-          "name": "system_prompt",
-          "type": {
-            "type": "str"
-          },
-          "default": "",
-          "title": "System Prompt",
-          "description": "Optional system prompt to provide context or instructions"
-        },
-        {
-          "name": "model",
-          "type": {
-            "type": "enum",
-            "values": [
-              "anthropic/claude-3.5-sonnet",
-              "anthropic/claude-3-5-haiku",
-              "anthropic/claude-3-haiku",
-              "google/gemini-pro-1.5",
-              "google/gemini-flash-1.5",
-              "google/gemini-flash-1.5-8b",
-              "meta-llama/llama-3.2-1b-instruct",
-              "meta-llama/llama-3.2-3b-instruct",
-              "meta-llama/llama-3.1-8b-instruct",
-              "meta-llama/llama-3.1-70b-instruct",
-              "openai/gpt-4o-mini",
-              "openai/gpt-4o"
-            ],
-            "type_name": "nodetool.nodes.fal.llm.ModelEnum"
-          },
-          "default": "google/gemini-flash-1.5",
-          "title": "Model",
-          "description": "The language model to use for the completion"
-        }
-      ],
-      "outputs": [
-        {
-          "type": {
-            "type": "str"
-          },
-          "name": "output"
-        }
-      ],
-      "basic_fields": [
-        "prompt",
-        "model",
-        "system_prompt"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- implement `Veo3` text-to-video node and DSL
- include Veo3 in FAL node package metadata

## Testing
- `nodetool package scan`
- `nodetool codegen`
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6855d3907a3c832f820eeaa8eb1f6ae0